### PR TITLE
[WIP] Import and unify the rule syntax and classical pattern matching system from SymbolicUtils.jl

### DIFF
--- a/src/EGraphs/ematch.jl
+++ b/src/EGraphs/ematch.jl
@@ -131,11 +131,8 @@ function lookup_pat(g::EGraph, p::PatTerm)
     end
 end
 
-function lookup_pat(g::EGraph, p::PatLiteral)
-    # println("looking up literal $p")
-    ec = lookup(g, ENodeLiteral(p.val))
-    return ec
-end
+lookup_pat(g::EGraph, p::Any) = lookup(g, ENodeLiteral(p))
+lookup_pat(g::EGraph, p::Pattern) = throw(UnsupportedPatternException(p))
 
 function (m::Machine)(instr::Lookup, pc) 
     # @show instr

--- a/src/EGraphs/subst.jl
+++ b/src/EGraphs/subst.jl
@@ -26,14 +26,9 @@ function instantiate(g::EGraph, pat::PatVar, sub::Sub, rule::AbstractRule)
     end
 end
 
-function instantiate(g::EGraph, pat::PatLiteral{T}, sub::Sub, rule::AbstractRule) where T
-    pat.val
-end
-
-function instantiate(g::EGraph, pat::PatTypeAssertion, sub::Sub, rule::AbstractRule)
-    instantiate(g, pat.name, sub, rule)
-end
-
+instantiate(g::EGraph, pat::Any, sub::Sub, rule::AbstractRule) = p
+instantiate(g::EGraph, pat::Pattern, sub::Sub, rule::AbstractRule) = 
+    throw(UnsupportedPatternException(p))
 
 function instantiate(g::EGraph, pat::PatTerm, sub::Sub, rule::AbstractRule)
     eh = exprhead(pat)

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -14,6 +14,8 @@ macro log(args...)
     quote options.verbose && @info($(args...)) end |> esc
 end
 
+@inline alwaystrue(x) = true
+
 export options
 
 include("Util/Util.jl")

--- a/src/Patterns/Patterns.jl
+++ b/src/Patterns/Patterns.jl
@@ -1,8 +1,11 @@
 module Patterns 
     using ..Util
 
+    import ..alwaystrue
+
     include("pattern.jl")
     include("toexpr.jl")
     include("patterns_syntax.jl")
+    include("errors.jl")
     include("exports.jl")
 end

--- a/src/Patterns/errors.jl
+++ b/src/Patterns/errors.jl
@@ -1,0 +1,7 @@
+struct UnsupportedPatternException <: Exception
+    p::Pattern
+end
+
+Base.showerror(io::IO, e::UnsupportedPatternException) = 
+    print(io, "Pattern", e.p, "is unsupported in this context")
+

--- a/src/Patterns/exports.jl
+++ b/src/Patterns/exports.jl
@@ -1,12 +1,9 @@
 # include("rules/patterns.jl")
 export Pattern
-export PatLiteral
 export PatVar
 export PatTerm
-export PatAllTerm
-export PatTypeAssertion
-export PatSplatVar
-export PatEquiv
+export PatSegment
 export patvars
 export @pat
 export isground
+export UnsupportedPatternException

--- a/src/Patterns/pattern.jl
+++ b/src/Patterns/pattern.jl
@@ -7,120 +7,72 @@ You can use the `Pattern` constructor to recursively convert an `Expr` (or any t
 """
 abstract type Pattern end
 
-import Base.==
-==(a::Pattern, b::Pattern) = false
+Base.isequal(a::Pattern, b::Pattern) = false
 TermInterface.arity(p::Pattern) = 0
+"""
+A ground pattern contains no pattern variables and 
+only literal values to match.
+"""
 isground(p::Pattern) = false
+isground(x) = true # literals
 
+@inline alwaystrue(x) = true
 
+# PatVar is equivalent to SymbolicUtils's Slot
 """
-Pattern variables will first match on any subterm
-and instantiate the substitution to that subterm. 
+    PatVar{P}(name, debrujin_index, predicate::P)
+
+Pattern variables will first match on one subterm
+and instantiate the substitution to that subterm.
+
+Matcher pattern may contain pattern variables with attached predicates,
+where `predicate` is a function that takes a matched expression and returns a
+boolean value. Such a slot will be considered a match only if `f` returns true.
+
+`predicate` can also be a `Type{<:t}`, this predicate is called a 
+type assertion. Type assertions on a `PatVar`, will match if and only if 
+the type of the matched term for the pattern variable is a subtype of `T`. 
 """
-mutable struct PatVar <: Pattern
-    name::Symbol
-    idx::Int
+mutable struct PatVar{P} <: Pattern 
+    name::Symbol 
+    idx::Int 
+    predicate::P 
 end
-function ==(a::PatVar, b::PatVar)
+function Base.isequal(a::PatVar, b::PatVar)
     # (a.name == b.name)
     a.idx == b.idx
 end
-PatVar(var) = PatVar(var, -1)
-
-"""
-A pattern literal will match only against an instance of itself.
-Example:
-```julia
-PatLiteral(2)
-```
-Will match only against values that are equal (using `Base.(==)`) to 2.
-
-```julia
-PatLiteral(:a)
-```
-Will match only against instances of the literal symbol `:a`.
-"""
-@auto_hash_equals struct PatLiteral{T} <: Pattern
-    val::T
-end
-isground(p::PatLiteral) = true
+PatVar(var) = PatVar(var, -1, alwaystrue)
 
 
 """
-Type assertions on a [`PatVar`](@ref), will match if and only if 
-the type of the matched term for the pattern variable `var` is a subtype 
-of `type`.
-Type assertions are supported in the left hand of rules
-to match and access literal values both when using classic
-rewriting and EGraph based rewriting.
-To use a type assertion pattern, add `::T` after
-a pattern variable in the `left_hand` of a rule.
+If you want to match a variable number of subexpressions at once, you will need
+a **segment pattern**. 
+A segment pattern represents a vector of subexpressions matched. 
+You can attach a predicate `g` to a segment variable. In the case of segment variables `g` gets a vector of 0 or more 
+expressions and must return a boolean value. 
 """
-struct PatTypeAssertion <: Pattern
-    var::PatVar
-    type::Type
+struct PatSegment{P} <: Pattern
+    name::Symbol
+    predicate::P
     hash::Ref{UInt}
-    PatTypeAssertion(v,t) = new(v, t, Ref{UInt}(0))
 end
-function Base.hash(t::PatTypeAssertion, salt::UInt)
+
+PatSegment(v) = new{typeof(alwaystrue)}(v, alwaystrue, Ref{UInt}(0))
+
+function Base.hash(t::PatSegment, salt::UInt)
     !iszero(salt) && return hash(hash(t, zero(UInt)), salt)
     h = t.hash[]
     !iszero(h) && return h
-    h′ = hash(t.var,  hash(t.type, salt))
+    h′ = hash(t.var, hash(t.predicate, salt))
     t.hash[] = h′
     return h′
-end
-
-
-struct PatSplatVar <: Pattern
-    var::PatVar
-    hash::Ref{UInt}
-    PatSplatVar(v) = new(v, Ref{UInt}(0))
-end
-function Base.hash(t::PatSplatVar, salt::UInt)
-    !iszero(salt) && return hash(hash(t, zero(UInt)), salt)
-    h = t.hash[]
-    !iszero(h) && return h
-    h′ = hash(t.var, salt)
-    t.hash[] = h′
-    return h′
-end
-
-
-"""
-This type of pattern will match if and only if 
-the two subpatterns exist in the same equivalence class,
-in the e-graph on which the matching is performed.
-**Can be used only in the e-graphs backend**
-"""
-struct PatEquiv <: Pattern
-    left::Pattern
-    right::Pattern
-    hash::Ref{UInt}
-    PatEquiv(l,r) = new(l,r, Ref{UInt}(0))
-end
-
-function ==(a::PatEquiv, b::PatEquiv)
-    a.left == b.left && a.right == b.right
-end
-
-function Base.hash(t::PatEquiv, salt::UInt)
-    !iszero(salt) && return hash(hash(t, zero(UInt)), salt)
-    h = t.hash[]
-    !iszero(h) && return h
-    h′ = hash(t.left,  hash(t.right, salt))
-    t.hash[] = h′
-    return h′
-end
-
-function isground(p::PatEquiv)
-   isground(p.left) && isground(p.right)
 end
 
 """
 Term patterns will match
 on terms of the same `arity` and with the same 
-function symbol (`head`).
+function symbol `operation` and expression head `exprhead`.
 """
 struct PatTerm <: Pattern
     exprhead::Any
@@ -146,18 +98,6 @@ end
 
 isground(p::PatTerm) = all(isground, p.args)
 
-"""
-This pattern type matches on a function application 
-but instead of strictly matching on a head symbol, 
-it has a pattern variable as head. It can be used for 
-example to match arbitrary function calls.
-"""
-@auto_hash_equals struct PatAllTerm <: Pattern
-    head::PatVar
-    args::Vector{Pattern}
-end
-TermInterface.arity(p::PatAllTerm) = length(p.args)
-
 
 # ==============================================
 # ================== PATTERN VARIABLES =========
@@ -166,24 +106,10 @@ TermInterface.arity(p::PatAllTerm) = length(p.args)
 """
 Collects pattern variables appearing in a pattern into a vector of symbols
 """
-patvars(p::PatLiteral, s) = s 
 patvars(p::PatVar, s) = push!(s, p.name)
-patvars(p::PatTypeAssertion, s) = patvars(p.var, s)
-patvars(p::PatSplatVar, s) = patvars(p.var, s)
-function patvars(p::PatEquiv, s)
-    patvars(p.left, s)
-    patvars(p.right, s)    
-end
+patvars(p::PatSegment, s) = patvars(p.var, s)
 
 function patvars(p::PatTerm, s)
-    for x ∈ p.args 
-        patvars(x, s)
-    end
-    return s
-end 
-
-function patvars(p::PatAllTerm, s)
-    push!(s, p.head.name)
     for x ∈ p.args 
         patvars(x, s)
     end
@@ -198,18 +124,10 @@ end
 # ================== DEBRUJIN INDEXING =========
 # ==============================================
 
-Base.setindex!(p::PatLiteral, pvars) = nothing 
 function Base.setindex!(p::PatVar, pvars)
     p.idx = findfirst((==)(p.name), pvars)
 end
-Base.setindex!(p::PatTypeAssertion, pvars) = setindex!(p.var, pvars)
-Base.setindex!(p::PatSplatVar, pvars) = setindex!(p.var, pvars)
-
-
-function Base.setindex!(p::PatEquiv, pvars)
-    setindex!(p.left, pvars)
-    setindex!(p.right, pvars)
-end 
+Base.setindex!(p::PatSegment, pvars) = setindex!(p.var, pvars)
 
 function Base.setindex!(p::PatTerm, pvars)
     for x ∈ p.args 
@@ -217,10 +135,4 @@ function Base.setindex!(p::PatTerm, pvars)
     end
 end 
 
-function Base.setindex!(p::PatAllTerm, pvars)
-    setindex!(p.head, pvars)
-    for x ∈ p.args 
-        setindex!(x, pvars)
-    end
-end 
 

--- a/src/Patterns/pattern.jl
+++ b/src/Patterns/pattern.jl
@@ -16,8 +16,6 @@ only literal values to match.
 isground(p::Pattern) = false
 isground(x) = true # literals
 
-@inline alwaystrue(x) = true
-
 # PatVar is equivalent to SymbolicUtils's Slot
 """
     PatVar{P}(name, debrujin_index, predicate::P)

--- a/src/Patterns/toexpr.jl
+++ b/src/Patterns/toexpr.jl
@@ -18,7 +18,7 @@ to_expr(x::PatSegment{typeof(alwaystrue)}) =
     Expr(:call, :~, Expr(:call, :~, Expr(:call, :~, x.name)))
 to_expr(x::PatSegment{T}) where {T<:Function} = 
     Expr(:call, :~, Expr(:call, :~, Expr(:(::), x.name, nameof(T))))
-to_expr(x::PatVar{<:Type{T}}) where T = 
+to_expr(x::PatSegment{<:Type{T}}) where T = 
     Expr(:call, :~, Expr(:call, :~, Expr(:(::), x.name, T)))
 
 function to_expr(x::PatTerm) 

--- a/src/Rules/rule_dsl.jl
+++ b/src/Rules/rule_dsl.jl
@@ -32,15 +32,6 @@ end
 rule_sym_map(ex) = error("Cannot parse rule from $ex")
 
 
-interp_dollar(x, mod::Module) = x
-function interp_dollar(ex::Expr, mod::Module)
-    if Meta.isexpr(ex, :$) # interpolate if it's a dollar expr
-        mod.eval(ex.args[1])
-    else # recurse
-        Expr(ex.head, map(x -> interp_dollar(x, mod), ex.args)...)
-    end
-end
-
 
 """
 Construct an `AbstractRule` from a quoted expression.
@@ -52,12 +43,6 @@ function Rule(e::Expr, mod::Module=@__MODULE__, resolve_fun=false)
     RuleType = rule_sym_map(e)
     l, r = e.args[Meta.isexpr(e, :call) ? (2:3) : (1:2)]
     
-    l = interp_dollar(l, mod)
-
-    if RuleType !== DynamicRule
-        r = interp_dollar(r, mod)
-    end
-
     lhs = Pattern(l, mod, resolve_fun)
     rhs = r
     

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -5,6 +5,7 @@ module EMatchCompiler
 using AutoHashEquals
 using TermInterface
 using ..Patterns
+import ..alwaystrue
 
 abstract type Instruction end 
 export Instruction
@@ -118,7 +119,7 @@ end
 
 
 function compile_ground!(reg, p::Pattern, prog)
-    Fail(ErrorException("Unsupported type of pattern for e-matching."))
+    throw(UnsupportedPatternException(p))
 end
 
 # A literal that is not a pattern
@@ -176,16 +177,16 @@ end
 
 function compile_pat!(reg, p::PatVar, prog)
     ifnew(_::typeof(alwaystrue)) = nothing 
-    ifnew(_::T<:Function) where T = 
+    ifnew(_::T) where T<:Function = 
         push!(prog.instructions, CheckPredicate(reg, p.predicate))
     ifnew(_::Type{T}) where T = 
-        push!(prog.instructions, CheckType(reg, p.type))
+        push!(prog.instructions, CheckType(reg, T))
 
     compile_patvar(ifnew, reg, p, prog)
 end
 
 function compile_pat!(reg, p::Pattern, prog)
-    Fail(ErrorException("Unsupported type of pattern for e-matching."))
+    throw(UnsupportedPatternException(p))
 end
 
 # Literal values
@@ -218,6 +219,7 @@ function compile_pat(p::Pattern)
     compile_pat!(prog.first_nonground, p, prog)
     push!(prog.instructions, Yield(prog.regs))
     # println("compiled pattern $p to \n $prog")
+    @show prog
     return prog
 end
 


### PR DESCRIPTION
- [x] Pattern types
- [ ] Pattern/rule syntax eDSL
- [ ] Classical pattern matcher
- [ ] E-Graphs pattern matcher
- [ ] Update tests with new syntax
- [ ] Bring docs over