### PR TITLE
fix small typo in egraphs.md

### DIFF
--- a/docs/src/egraphs.md
+++ b/docs/src/egraphs.md
@@ -85,7 +85,7 @@ of the equality saturation process.
 a `timeout` on the number of iterations, a `eclasslimit` on the number of e-classes in the EGraph, a `stopwhen` functions that stops saturation when it evaluates to true.
 ```julia
 g = EGraph(:((a * b) * (1 * (b + c))));
-report = saturate!(G, t);
+report = saturate!(g, t);
 # access the saturated EGraph
 report.egraph
 


### PR DESCRIPTION
unless I am misunderstanding something fundamental here, the 1st parameter passed to `saturate!` is the `EGraph` constructed a line above.