### PR TITLE
bump `DocStringExtensions`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 [compat]
 AutoHashEquals = "0.2.0"
 DataStructures = "0.18.9"
-DocStringExtensions = "0.8"
+DocStringExtensions = "0.8, 0.9"
 Parameters = "0.12"
 Reexport = "0.2, 1"
 TermInterface = "0.2.3"


### PR DESCRIPTION
Following this PR, a `Metatheory` version bump to `1.4.1` would be appreciated.