### PR TITLE
Pretty printing, fix for graph plots & minor docs improvement

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -45,6 +45,16 @@ Modules = [Metatheory.Rewriters]
 Modules = [Metatheory.EGraphs]
 ```
 
+## VecExprs (aka e-nodes)
+
+```@docs
+Metatheory.VecExprModule.VecExpr
+```
+
+```@autodocs
+Modules = [Metatheory.VecExprModule]
+```
+
 ---
 
 ## EGraph Schedulers

--- a/docs/src/egraphs.md
+++ b/docs/src/egraphs.md
@@ -35,7 +35,7 @@ system governed by equational rules, about non obviously oriented equations, suc
 )`?
 
 E-Graphs come to our help. 
-EGraphs are bipartite graphs of e-nodes (stored in [VecExpr](@ref)s) and [EClass](@ref)es:
+EGraphs are bipartite graphs of e-nodes (stored in [`VecExpr`](@ref)s) and [`EClass`](@ref)es:
 a data structure for efficiently represent and rewrite on many equivalent expressions at the same time. A sort of fast data structure for sets of trees. Subtrees and parents are shared if possible. This makes EGraphs similar to DAGs.
 Most importantly, with EGraph rewriting you can use **bidirectional rewrite rules**, such as **equalities** without worrying about
 the ordering and confluence of your rewrite system!

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -55,7 +55,7 @@ Base.iterate(a::EClass, state) = iterate(a.nodes, state)
 
 # Showing
 function Base.show(io::IO, a::EClass)
-  println(io, "$(typeof(a)) #$(a.id) with $(length(a.nodes)) e-nodes:")
+  println(io, "$(typeof(a)) %$(a.id) with $(length(a.nodes)) e-nodes:")
   println(io, " data: $(a.data)")
   println(io, " nodes:")
   for n in a.nodes

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -36,7 +36,7 @@ function make end
 An `EClass` is an equivalence class of terms.
 
 The children and parent nodes are stored as [`VecExpr`](@ref)s for performance, which
-means that without the [`EGraph`](@ref) we cannot see the human-readable terms
+means that without a reference to the [`EGraph`](@ref) object we cannot re-build human-readable terms
 they represent. The [`EGraph`](@ref) itself comes with pretty printing for humean-readable terms.
 """
 mutable struct EClass{D}

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -55,7 +55,7 @@ Base.iterate(a::EClass, state) = iterate(a.nodes, state)
 
 # Showing
 function Base.show(io::IO, a::EClass)
-  println(io, "EClass #$(a.id) with $(length(a.nodes)) e-nodes:")
+  println(io, "$(typeof(a)) #$(a.id) with $(length(a.nodes)) e-nodes:")
   println(io, " data: $(a.data)")
   println(io, " nodes:")
   for n in a.nodes

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -55,10 +55,12 @@ Base.iterate(a::EClass, state) = iterate(a.nodes, state)
 
 # Showing
 function Base.show(io::IO, a::EClass)
-  print(io, "EClass $(a.id) (")
-  print(io, "[", Base.join(a.nodes, ", "), "], ")
-  print(io, a.data)
-  print(io, ")")
+  println(io, "EClass #$(a.id) with $(length(a.nodes)) e-nodes:")
+  println(io, " data: $(a.data)")
+  println(io, " nodes:")
+  for n in a.nodes
+    println(io, "    $n")
+  end
 end
 
 function addparent!(@nospecialize(a::EClass), n::VecExpr, id::Id)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -81,6 +81,8 @@ end
 A concrete type representing an [`EGraph`].
 See the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304)
 for implementation details.
+
+
 """
 mutable struct EGraph{ExpressionType,Analysis}
   "stores the equality relations over e-class ids"
@@ -191,7 +193,9 @@ end
 export pretty_dict
 
 function Base.show(io::IO, g::EGraph)
-  show(io, pretty_dict(g))
+  d = pretty_dict(g)
+  t = "$(typeof(g)) with $(length(d)) e-classes:"
+  print(io, Base.join([t; map(((k,v),)->"  $k => $v", collect(d))], "\n"))
 end
 
 function enode_op_key(@nospecialize(g::EGraph), n::VecExpr)::Pair{UInt64,Int}

--- a/src/extras/graphviz.jl
+++ b/src/extras/graphviz.jl
@@ -24,7 +24,7 @@ function render_eclass!(io::IO, g::EGraph, eclass::EClass)
     """    subgraph cluster_$(eclass.id) {
          style="dotted,rounded";
          rank=same;
-         label="#$(eclass.id). Smallest: $(extract!(g, astsize))"
+         label="%$(eclass.id). Smallest: $(extract!(g, astsize, eclass.id))"
          fontcolor = gray
          fontsize  = 8
    """,

--- a/src/extras/graphviz.jl
+++ b/src/extras/graphviz.jl
@@ -24,7 +24,7 @@ function render_eclass!(io::IO, g::EGraph, eclass::EClass)
     """    subgraph cluster_$(eclass.id) {
          style="dotted,rounded";
          rank=same;
-         label="#$(eclass.id). Smallest: $(extract!(g, astsize; root=eclass.id))"
+         label="#$(eclass.id). Smallest: $(extract!(g, astsize))"
          fontcolor = gray
          fontsize  = 8
    """,
@@ -47,7 +47,7 @@ end
 
 
 function render_enode_node!(io::IO, g::EGraph, eclass_id, i::Int, node::VecExpr)
-  label = head(node)
+  label = get_constant(g, v_head(node))
   # (mr, style) = if node in diff && get(report.cause, node, missing) !== missing
   #   pair = get(report.cause, node, missing)
   #   split(split("$(pair[1].rule) ", "=>")[1], "-->")[1], " color=\"red\""
@@ -59,9 +59,9 @@ function render_enode_node!(io::IO, g::EGraph, eclass_id, i::Int, node::VecExpr)
 end
 
 function render_enode_edges!(io::IO, g::EGraph, eclass_id, i, node::VecExpr)
-  node.isexpr || return nothing
-  len = length(arguments(node))
-  for (ite, child) in enumerate(arguments(node))
+  v_isexpr(node) || return nothing
+  len = length(v_children(node))
+  for (ite, child) in enumerate(v_children(node))
     cluster_id = find(g, child)
     # The limitation of graphviz is that it cannot point to the eclass outer frame, 
     # so when pointing to the same e-class, the next best thing is to point to the same e-node.

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -26,7 +26,7 @@ const Id = UInt64
 """
     const VecExpr = Vector{Id}
 
-An e-node is a `Vector{ID}` where:
+An e-node is a `Vector{Id}` where:
 * Position 1 stores the hash of the `VecExpr`.
 * Position 2 stores the bit flags (`isexpr` or `iscall`).
 * Position 3 stores the index of the `head` (if `isexpr`) or value in the e-graph constants.

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -28,8 +28,8 @@ const Id = UInt64
 
 An e-node is a `Vector{ID}` where:
 * Position 1 stores the hash of the `VecExpr`.
-* Position 2 stores the bit flags (`istree` or `iscall`).
-* Position 3 stores the index of the `head` (if `istree`) or value in the e-graph constants.
+* Position 2 stores the bit flags (`isexpr` or `iscall`).
+* Position 3 stores the index of the `head` (if `isexpr`) or value in the e-graph constants.
 * The rest of the positions store the e-class ids of the children nodes.
 """
 const VecExpr = Vector{Id}
@@ -43,9 +43,13 @@ const VECEXPR_META_LENGTH = 3
 @inline v_check_flags(n::VecExpr, flag::Id)::Bool = !iszero(v_flags(n) & flags)
 @inline v_set_flag!(n::VecExpr, flag)::Id = @inbounds (n[2] = n[2] | flag)
 
+"""Returns `true` if the e-node ID points to a an expression tree."""
 @inline v_isexpr(n::VecExpr)::Bool = !iszero(v_flags(n) & VECEXPR_FLAG_ISTREE)
+
+"""Returns `true` if the e-node ID points to a function call."""
 @inline v_iscall(n::VecExpr)::Bool = !iszero(v_flags(n) & VECEXPR_FLAG_ISCALL)
 
+"""Number of children in the e-node."""
 @inline v_arity(n::VecExpr)::Int = length(n) - VECEXPR_META_LENGTH
 
 """
@@ -61,13 +65,22 @@ Compute the hash of a `VecExpr` and store it as the first element.
   end
 end
 
+"""The hash of the e-node."""
 @inline v_hash(n::VecExpr)::Id = @inbounds n[1]
+
+"""Set e-node hash to zero."""
 @inline v_unset_hash!(n::VecExpr)::Id = @inbounds (n[1] = Id(0))
 
+"""E-class IDs of the children of the e-node."""
 @inline v_children(n::VecExpr) = @view n[(VECEXPR_META_LENGTH + 1):end]
+
+"""E-node ID."""
 @inline v_head(n::VecExpr)::Id = @inbounds n[VECEXPR_META_LENGTH]
+
+"""Update the E-node ID."""
 @inline v_set_head!(n::VecExpr, h::Id) = @inbounds (n[3] = h)
 
+"""Construct a new, empty `VecExpr` with `len` children."""
 @inline function v_new(len::Int)::VecExpr
   n = Vector{Id}(undef, len + VECEXPR_META_LENGTH)
   v_unset_hash!(n)

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -24,16 +24,14 @@ export Id,
 const Id = UInt64
 
 """
-VecExpr vector syntax:
+    const VecExpr = Vector{Id}
 
-An e-node is a vector of `Id`
-
-Position 1 stores the hash
-Position 2 stores the bit flags (is tree, is function call)
-Position 3 stores the index of the head (if is tree) or value in the e-graph constants
-Rest of positions store the e-class ids of the children
+An e-node is a `Vector{ID}` where:
+* Position 1 stores the hash of the `VecExpr`.
+* Position 2 stores the bit flags (`istree` or `iscall`).
+* Position 3 stores the index of the `head` (if `istree`) or value in the e-graph constants.
+* The rest of the positions store the e-class ids of the children nodes.
 """
-
 const VecExpr = Vector{Id}
 
 const VECEXPR_FLAG_ISTREE = 0x01

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -74,10 +74,10 @@ end
 """E-class IDs of the children of the e-node."""
 @inline v_children(n::VecExpr) = @view n[(VECEXPR_META_LENGTH + 1):end]
 
-"""E-node ID."""
+"The constant ID of the operation of the e-node, or the e-node ."
 @inline v_head(n::VecExpr)::Id = @inbounds n[VECEXPR_META_LENGTH]
 
-"""Update the E-node ID."""
+"Update the E-Node operation ID."
 @inline v_set_head!(n::VecExpr, h::Id) = @inbounds (n[3] = h)
 
 """Construct a new, empty `VecExpr` with `len` children."""


### PR DESCRIPTION
This fixes the `GraphViz.jl` visualizations and makes printing egraphs a bit more friendly:
```julia
julia> EGraph(:(a-a))
EGraph{Expr, Nothing} with 2 e-classes:
  2 => [:(%1 - %1)]
  1 => [:a]
```

I could also add a couple of lines to the `EGraph`/`EClass` doc strings to describe how to get eclasses/enodes printed as their expressions and not as IDs from the `VexExpr`, what do you think @0x0f0f0f ?