### PR TITLE
Compiled Pattern Matching 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,18 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
+[weakdeps]
+GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
+
+[extensions]
+Plotting = ["GraphViz"]
+
 [compat]
 AutoHashEquals = "2.1.0"
 DocStringExtensions = "0.8, 0.9"
 Reexport = "0.2, 1"
-TimerOutputs = "0.5"
 TermInterface = "0.4.1"
+TimerOutputs = "0.5"
 julia = "1.9"
 
 [extras]
@@ -26,9 +32,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Documenter", "SafeTestsets", "Literate"]
-
-[weakdeps]
-GraphViz = "f526b714-d49f-11e8-06ff-31ed36ee7ee0"
-
-[extensions]
-Plotting = ["GraphViz"]

--- a/examples/propositional_logic_theory.jl
+++ b/examples/propositional_logic_theory.jl
@@ -1,5 +1,7 @@
 # # Rewriting 
 
+using Metatheory, TermInterface
+
 fold = @theory p q begin
   (p::Bool == q::Bool) => (p == q)
   (p::Bool || q::Bool) => (p || q)
@@ -74,7 +76,7 @@ function prove(
     params.goal = (g::EGraph) -> in_same_class(g, ids...)
     saturate!(g, t, params)
     ex = extract!(g, astsize)
-    if !Metatheory.isexpr(ex)
+    if !TermInterface.isexpr(ex)
       return ex
     end
     if hash(ex) ∈ hist

--- a/src/EGraphs/EGraphs.jl
+++ b/src/EGraphs/EGraphs.jl
@@ -8,7 +8,7 @@ using Metatheory.Patterns
 using Metatheory.Rules
 using Metatheory.VecExprModule
 
-using Metatheory: alwaystrue, cleanast, UNDEF_ID_VEC, should_quote_operation, OptBuffer
+using Metatheory: alwaystrue, cleanast, UNDEF_ID_VEC, maybe_quote_operation, OptBuffer
 
 import Metatheory: to_expr
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -330,7 +330,7 @@ function addexpr!(g::EGraph, se)::Id
     v_set_head!(n, add_constant!(g, h))
 
     # get the signature from op and arity 
-    v_set_signature!(n, hash(should_quote_operation(h) ? nameof(h) : h, hash(ar)))
+    v_set_signature!(n, hash(maybe_quote_operation(h), hash(ar)))
 
     for i in v_children_range(n)
       @inbounds n[i] = addexpr!(g, args[i - VECEXPR_META_LENGTH])

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -87,14 +87,14 @@ function eqsat_search!(
 
       if rule isa BidirRule
         for i in ids_left
-          n_matches += rule.ematcher_new_left!(g, rule_idx, i, rule.ematcher_stack, ematch_buffer)
+          n_matches += rule.ematcher_new_left!(g, rule_idx, i, rule.stack, ematch_buffer)
         end
         for i in ids_right
-          n_matches += rule.ematcher_new_right!(g, rule_idx, i, rule.ematcher_stack, ematch_buffer)
+          n_matches += rule.ematcher_new_right!(g, rule_idx, i, rule.stack, ematch_buffer)
         end
       else
         for i in ids_left
-          n_matches += rule.ematcher!(g, rule_idx, i, rule.ematcher_stack, ematch_buffer)
+          n_matches += rule.ematcher!(g, rule_idx, i, rule.stack, ematch_buffer)
         end
       end
       n_matches - prev_matches > 0 && @debug "Rule $rule_idx: $rule produced $(n_matches - prev_matches) matches"

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -8,9 +8,8 @@ using Reexport
 function to_expr end
 
 # TODO: document
-function should_quote_operation end
-should_quote_operation(::Function) = true
-should_quote_operation(x) = false
+Base.@inline maybe_quote_operation(x::Union{Function,DataType}) = nameof(x)
+Base.@inline maybe_quote_operation(x) = x
 
 include("docstrings.jl")
 

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -64,6 +64,10 @@ export @timer
 include("Patterns.jl")
 @reexport using .Patterns
 
+include("match_compiler.jl")
+export match_compile
+
+
 include("ematch_compiler.jl")
 export ematch_compile
 

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -22,8 +22,7 @@ export OptBuffer
 
 const UNDEF_ID_VEC = Vector{Id}(undef, 0)
 
-using TermInterface
-using TermInterface: isexpr
+@reexport using TermInterface
 
 """ 
   @matchable struct Foo fields... end [HeadType]

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -1,6 +1,6 @@
 module Patterns
 
-using Metatheory: cleanast, alwaystrue, should_quote_operation
+using Metatheory: cleanast, alwaystrue, maybe_quote_operation
 using AutoHashEquals
 using TermInterface
 using Metatheory.VecExprModule
@@ -92,7 +92,9 @@ struct PatExpr <: AbstractPat
   n::VecExpr
   function PatExpr(iscall, op, args::Vector)
     op_hash = hash(op)
-    qop, qop_hash = should_quote_operation(op) ? (nameof(op), hash(nameof(op))) : (op, op_hash)
+    # Should call `nameof` on op if Function or DataType. Identity otherwise
+    qop = maybe_quote_operation(op)
+    qop_hash = hash(qop)
     ar = length(args)
     signature = hash(qop, hash(ar))
 

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -70,7 +70,6 @@ Base.show(io::IO, r::RewriteRule) = print(io, :($(r.left) --> $(r.right)))
 function (r::RewriteRule)(term)
   # n == 1 means that exactly one term of the input (term,) was matched
   success(pvars...) = instantiate(term, r.right, pvars)
-
   try
     r.matcher(term, success, r.stack)
   catch err

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -98,7 +98,7 @@ with the EGraphs backend.
   patvars::Vector{Symbol}
   ematcher_new_left!
   ematcher_new_right!
-  ematcher_stack::OptBuffer{UInt16}
+  stack::OptBuffer{UInt16}
 end
 
 function EqualityRule(l, r, ematcher_new_left!, ematcher_new_right!)
@@ -136,7 +136,7 @@ backend. If two terms, corresponding to the left and right hand side of an
   patvars::Vector{Symbol}
   ematcher_new_left!
   ematcher_new_right!
-  ematcher_stack::OptBuffer{UInt16}
+  stack::OptBuffer{UInt16}
 end
 
 function UnequalRule(l, r, ematcher_new_left!, ematcher_new_right!)

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -382,7 +382,7 @@ macro rule(args...)
     rhs = :($(esc(params)) -> $(esc(rhs_consequent)))
     return quote
       $(__source__)
-      DynamicRule($lhs, $rhs, $ematcher_left_expr, $(QuoteNode(rhs_consequent)))
+      DynamicRule($lhs, $rhs, $matcher_left_expr, $ematcher_left_expr, $(QuoteNode(rhs_consequent)))
     end
   end
 

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -3,7 +3,7 @@ using Metatheory.Patterns
 using Metatheory.Rules
 using TermInterface
 
-using Metatheory: alwaystrue, cleanast, ematch_compile
+using Metatheory: alwaystrue, cleanast, ematch_compile, match_compile
 
 export @rule
 export @theory
@@ -373,6 +373,8 @@ macro rule(args...)
   end
   ematcher_left_expr = esc(ematch_compile(lhs, ppvars, 1))
 
+  matcher_left_expr = esc(match_compile(lhs, pvars))
+
   if RuleType == DynamicRule
     rhs_rewritten = rewrite_rhs(r)
     rhs_consequent = makeconsequent(rhs_rewritten)
@@ -393,7 +395,7 @@ macro rule(args...)
 
   quote
     $(__source__)
-    ($RuleType)($lhs, $rhs, $ematcher_left_expr)
+    ($RuleType)($lhs, $rhs, $matcher_left_expr, $ematcher_left_expr)
   end
 end
 

--- a/src/match_compiler.jl
+++ b/src/match_compiler.jl
@@ -1,7 +1,7 @@
 using Metatheory: alwaystrue
 using TermInterface
 
-@kwdef mutable struct MatchCompilerState
+Base.@kwdef mutable struct MatchCompilerState
   pvars_bound::Vector{Bool}
   program::Vector{Expr} = Expr[]
   term_coord_variables = Pair{Symbol,Any}[]

--- a/src/match_compiler.jl
+++ b/src/match_compiler.jl
@@ -4,12 +4,13 @@ using TermInterface
 @kwdef mutable struct MatchCompilerState
   pvars_bound::Vector{Bool}
   program::Vector{Expr} = Expr[]
-  term_coord_variables = Symbol[]
+  term_coord_variables = Pair{Symbol,Any}[]
   segments::Vector{Symbol} = Symbol[]
-  current_term_has_segment = false
+  current_term_has_segment::Bool = false
+  current_term_n_remaining::Int = 0
 end
 
-function match_compile(p, pvars, direction)
+function match_compile(p::AbstractPat, pvars)
   npvars = length(pvars)
 
   state = MatchCompilerState(; pvars_bound = fill(false, npvars))
@@ -20,14 +21,16 @@ function match_compile(p, pvars, direction)
   # Example: in f(x, g(y, k, h(z))), to get z the coordinate is [2,3,1]
   coordinate = Int[]
 
-  match_compile!(p, state, coordinate)
+  match_compile!(p, state, coordinate, Symbol[])
   push!(state.program, :(return callback($(pvars...))))
 
   quote
     Base.@propagate_inbounds function ($(gensym("matcher")))(t, callback::Function, stack::OptBuffer{UInt16})
       # Assign and empty the variables for patterns 
       $([:($var = nothing) for var in pvars]...)
-      $([:($v = nothing) for v in state.term_coord_variables]...)
+
+      # Initialize the variables needed in the outermost scope (accessible by instruction blocks)
+      $([:($(Symbol(k)) = $v) for (k, v) in state.term_coord_variables]...)
 
       # Backtracking stack
       stack_idx = 0
@@ -75,35 +78,47 @@ function get_coord(coordinate, current_term_has_segment = false)
 
   tsym = make_coord_symbol(coordinate[1:(end - 1)])
   idx = if current_term_has_segment
-    offset_sym = Symbol(tsym, :_offset)
-    :($(last(coordinate)) + $offset_sym)
+    :($(last(coordinate)) + $(Symbol(tsym, :_offset)))
   else
     last(coordinate)
   end
   :($(Symbol(tsym, :_args))[$idx])
 end
 
-function match_compile!(pattern::PatExpr, state::MatchCompilerState, coordinate::Vector{Int})
+function match_compile!(pattern::PatExpr, state::MatchCompilerState, coordinate::Vector{Int}, parent_segments)
   push!(state.program, match_term_expr(pattern, coordinate, state.current_term_has_segment))
   t_sym = make_coord_symbol(coordinate)
-  !isempty(coordinate) && push!(state.term_coord_variables, t_sym)
-  push!(state.term_coord_variables, Symbol(t_sym, :_op))
-  push!(state.term_coord_variables, Symbol(t_sym, :_args))
+  !isempty(coordinate) && push!(state.term_coord_variables, t_sym => nothing)
+  push!(state.term_coord_variables, Symbol(t_sym, :_op) => nothing)
+  push!(state.term_coord_variables, Symbol(t_sym, :_args) => nothing)
   # The sum of how many terms have been taken by segments
 
   state.current_term_has_segment = false
 
-  for (i, child_pattern) in enumerate(arguments(pattern))
-    match_compile!(child_pattern, state, [coordinate; i])
+  p_args = arguments(pattern)
+  p_arity = length(p_args)
+  state.current_term_n_remaining = 0
+
+  segments_so_far = Symbol[]
+
+  for (i, child_pattern) in enumerate(p_args)
+    @show p_arity i
+    state.current_term_n_remaining = p_arity - i
+    match_compile!(child_pattern, state, [coordinate; i], segments_so_far)
   end
 
-  state.current_term_has_segment && push!(state.term_coord_variables, Symbol(t_sym, :_offset))
+  state.current_term_has_segment && push!(state.term_coord_variables, Symbol(t_sym, :_offset) => 0)
 
   state.current_term_has_segment = false
 end
 
 
-function match_compile!(patvar::Union{PatVar,PatSegment}, state::MatchCompilerState, coordinate::Vector{Int})
+function match_compile!(
+  patvar::Union{PatVar,PatSegment},
+  state::MatchCompilerState,
+  coordinate::Vector{Int},
+  parent_segments,
+)
   # Mark that the current term has a segment variable
   instruction = if state.pvars_bound[patvar.idx]
     # Pattern variable with the same Debrujin index has appeared in the  
@@ -113,18 +128,22 @@ function match_compile!(patvar::Union{PatVar,PatSegment}, state::MatchCompilerSt
     # Variable has not been seen before. Store it
     state.pvars_bound[patvar.idx] = true
     # insert instruction for checking predicates or type.
-    match_var_expr(patvar, coordinate, state.current_term_has_segment)
+    match_var_expr(patvar, state, coordinate, parent_segments)
   end
-  patvar isa PatSegment && (state.current_term_has_segment = true)
+  if patvar isa PatSegment
+    state.current_term_has_segment = true
+    push!(state.term_coord_variables, Symbol(patvar.name, :_n_dropped) => 0)
+    push!(parent_segments, patvar.name)
+  end
   push!(state.program, instruction)
 end
 
 
-function match_compile!(p::PatLiteral, state::MatchCompilerState, coordinate::Vector{Int})
+function match_compile!(p::PatLiteral, state::MatchCompilerState, coordinate::Vector{Int}, parent_segments)
   push!(state.program, match_eq_expr(p, coordinate, state.current_term_has_segment))
 end
 
-function match_compile!(p::AbstractPat, state::MatchCompilerState, coordinate::Vector{Int})
+function match_compile!(p::AbstractPat, state::MatchCompilerState, coordinate::Vector{Int}, parent_segments)
   # Pattern not supported.
   @show p
   push!(state.program, :(error("NOT SUPPORTED"); return 0))
@@ -153,8 +172,11 @@ function match_term_expr(pattern::PatExpr, coordinate, current_term_has_segment)
   quote
     $t = $(get_coord(coordinate, current_term_has_segment))
 
+    @show t
     isexpr($t) || @goto backtrack
-    iscall($t) == $(iscall(pattern)) || @goto backtrack
+
+    @show "DAJE"
+    iscall($t) === $(iscall(pattern)) || @goto backtrack
 
     $(Symbol(t, :_op)) = $(op_fun)($t)
     $(Symbol(t, :_args)) = $(args_fun)($t)
@@ -166,14 +188,14 @@ function match_term_expr(pattern::PatExpr, coordinate, current_term_has_segment)
   end
 end
 
-match_var_expr_if_guard(patvar::PatVar, predicate::Function) = :($(predicate)($patvar.name))
-match_var_expr_if_guard(patvar::PatVar, predicate::typeof(alwaystrue)) = true
-match_var_expr_if_guard(patvar::PatVar, T::Type) = :($(patvar.name) isa $T)
+match_var_expr_if_guard(patvar::Union{PatVar,PatSegment}, predicate::Function) = :($(predicate)($patvar.name))
+match_var_expr_if_guard(patvar::Union{PatVar,PatSegment}, predicate::typeof(alwaystrue)) = true
+match_var_expr_if_guard(patvar::Union{PatVar,PatSegment}, T::Type) = :($(patvar.name) isa $T)
 
 
-function match_var_expr(patvar::PatVar, coordinate, current_term_has_segment)
+function match_var_expr(patvar::PatVar, state::MatchCompilerState, coordinate, segments_so_far)
   quote
-    $(patvar.name) = $(get_coord(coordinate, current_term_has_segment))
+    $(patvar.name) = $(get_coord(coordinate, state.current_term_has_segment))
     if $(match_var_expr_if_guard(patvar, patvar.predicate))
       pc += 0x0001
       @goto compute
@@ -182,34 +204,62 @@ function match_var_expr(patvar::PatVar, coordinate, current_term_has_segment)
   end
 end
 
-function match_var_expr(patvar::PatSegment, coordinate, current_term_has_segment)
+function match_var_expr(patvar::PatSegment, state::MatchCompilerState, coordinate, segments_so_far)
   tsym = make_coord_symbol(coordinate[1:(end - 1)])
   tsym_args = Symbol(tsym, :_args)
   offset_sym = Symbol(tsym, :_offset)
+  n_dropped_sym = Symbol(patvar.name, :_n_dropped)
 
-  remaining
-
-  start_idx = if current_term_has_segment
+  start_idx = if state.current_term_has_segment
     :($(last(coordinate)) + $offset_sym)
   else
     last(coordinate)
   end
 
+  offset_so_far = foldl((x, y) -> :($x + $y), map(n -> :(length($n)), segments_so_far); init = 0)
+
+  @show offset_so_far
 
   quote
-    push!(stack, pc)
-
     start_idx = $start_idx
+    end_idx = length($tsym_args) - $(state.current_term_n_remaining)
 
-    for end_idx in ((length($tsym_args) - $remaining)):-1:(start_idx)
-      $(patvar.name) = view($tsym_args, start_idx:end_idx)
+    @show $(state.current_term_n_remaining)
+    @show length($tsym_args)
+
+    @show $offset_sym
+    @show start_idx end_idx $n_dropped_sym
+
+    if end_idx - $n_dropped_sym >= start_idx - 1
+      push!(stack, pc)
+
+      $(patvar.name) = view($tsym_args, start_idx:(end_idx - $n_dropped_sym))
+
+      @show start_idx
+      @show $tsym_args
+      @show $(patvar.name)
+
+      @show length($(patvar.name))
+      $offset_sym = length($(patvar.name)) + $offset_so_far - 1
+
+      @show $offset_sym
+
+      $n_dropped_sym += 1
+
+      if $offset_sym + $(state.current_term_n_remaining) >= length($tsym_args)
+        @goto backtrack
+      end
 
       if $(match_var_expr_if_guard(patvar, patvar.predicate))
         pc += 0x0001
         @goto compute
       end
+
+      @goto backtrack
     end
 
+    # Restart 
+    $n_dropped_sym = 0
     @goto backtrack
   end
 end
@@ -229,6 +279,7 @@ end
 
 function match_eq_expr(pat::PatLiteral, coordinate, current_term_has_segment)
   quote
+    @show $(QuoteNode(get_coord(coordinate, current_term_has_segment)))
     if $(pat.value) == $(get_coord(coordinate, current_term_has_segment))
       pc += 0x0001
       @goto compute

--- a/src/matchers.jl
+++ b/src/matchers.jl
@@ -149,34 +149,34 @@ function matcher(term::PatExpr)
   end
 end
 
-function instantiate(left, pat::PatExpr, mem)
+function instantiate(left, pat::PatExpr, bindings)
   ntail = []
   for parg in arguments(pat)
-    instantiate_arg!(ntail, left, parg, mem)
+    instantiate_arg!(ntail, left, parg, bindings)
   end
   maketerm(typeof(left), operation(pat), ntail)
 end
 
-function instantiate(left::Expr, pat::PatExpr, mem)
+function instantiate(left::Expr, pat::PatExpr, bindings)
   ntail = []
   if iscall(pat)
     for parg in arguments(pat)
-      instantiate_arg!(ntail, left, parg, mem)
+      instantiate_arg!(ntail, left, parg, bindings)
     end
     op = operation(pat)
     op_name = op isa Union{Function,DataType} ? nameof(op) : op
     maketerm(Expr, :call, [op_name; ntail])
   else
     for parg in children(pat)
-      instantiate_arg!(ntail, left, parg, mem)
+      instantiate_arg!(ntail, left, parg, bindings)
     end
     maketerm(Expr, head(pat), ntail)
   end
 end
 
-instantiate_arg!(acc, left, parg::PatSegment, mem) = append!(acc, instantiate(left, parg, mem))
-instantiate_arg!(acc, left, parg::AbstractPat, mem) = push!(acc, instantiate(left, parg, mem))
+instantiate_arg!(acc, left, parg::PatSegment, bindings) = append!(acc, instantiate(left, parg, bindings))
+instantiate_arg!(acc, left, parg::AbstractPat, bindings) = push!(acc, instantiate(left, parg, bindings))
 
-instantiate(_, pat::PatLiteral, mem) = pat.value
-instantiate(_, pat::Union{PatVar,PatSegment}, mem) = mem[pat.idx]
+instantiate(_, pat::PatLiteral, bindings) = pat.value
+instantiate(_, pat::Union{PatVar,PatSegment}, bindings) = bindings[pat.idx]
 

--- a/test/classic/reductions.jl
+++ b/test/classic/reductions.jl
@@ -168,7 +168,7 @@ end
 @testset "Multiple PatSegments" begin
   r = @rule f(~~x, ~~y) --> ok(~~x, yeah(~~y))
   sf = r(:(f(1, 2, 3, 4)))
-  @test sf == :(ok(1, 2, 3, yeah(4)))
+  @test sf == :(ok(1, 2, 3, 4, yeah()))
 
   r = @rule f(~~x, 3, ~~y) --> ok(~~x, yeah(~~y))
   sf = r(:(f(1, 2, 3, 4, 5)))
@@ -184,19 +184,25 @@ end
 end
 
 @testset "Multiple Repeated PatSegments" begin
-  r = @rule f(~~x, ~~x) --> ok(~~x)
-  sf = r(:(f(1, 2, 1, 2)))
-  @test sf == :(ok(1, 2))
-
-  sf = r(:(f(1, 2, 3, 4)))
-  @test isnothing(sf)
-
   r = @rule f(~~x, ~~x, 4) --> ok(~~x)
   sf = r(:(f(1, 2, 1, 2, 4)))
   @test sf == :(ok(1, 2))
 
   sf = r(:(f(1, 2, 3, 4)))
   @test isnothing(sf)
+
+  sf = r(:(f(4)))
+  @test sf == :(ok())
+
+
+  r = @rule f(~~x, ~~x) --> ok(~~x)
+  sf = r(:(f(1, 2, 1, 2)))
+  @test sf == :(ok(1, 2))
+
+  # TODO why?
+  sf = r(:(f(1, 2, 3, 4)))
+  @test isnothing(sf)
+
 
 
   r = @rule f(~~x, 3, ~~x) --> ok(~~x)
@@ -208,13 +214,17 @@ end
 
   # Appears 3 times, doesn't work because of `offset_so_far` not counting how many times 
   # a variable appears
-  r = @rule f(~~x, 3, ~~x, 5, ~~x) --> ok(~~x, yeah(~~y), ~~z)
+  r = @rule f(~~x, 3, ~~x, 5, ~~x) --> ok(~~x)
   sf = r(:(f(1, 2, 3, 1, 2, 5, 1, 2)))
-  @test sf == :(ok(1, 2, yeah(4), 6))
+  @test sf == :(ok(1, 2))
 
-  r = @rule f(~~x, 3, ~~y, 5, ~~z, 7) --> ok(~~x, yeah(~~y), ~~z)
-  sf = r(:(f(1, 2, 2, 3, 4, 4, 5, 6, 7, 7)))
-  @test sf == :(ok(1, 2, 2, yeah(4, 4), 6))
+  sf = r(:(f(1, 2, 3, 3, 1, 2, 5, 1, 2)))
+  @test isnothing(sf)
+
+
+  r = @rule f(~~x, 3, ~~y, 5, ~~x, ~~z, 7, ~~y) --> ok(~~x, yeah(~~y), ~~z)
+  sf = r(:(f(1, 2, 2, 3, 4, 4, 5, 1, 2, 2, 6, 7, 7, 4, 4)))
+  @test sf == :(ok(1, 2, 2, yeah(4, 4), 6, 7))
 end
 
 

--- a/test/classic/reductions.jl
+++ b/test/classic/reductions.jl
@@ -250,7 +250,6 @@ end
 end
 
 
-
 @testset "Pattern variable as pattern term head" begin
   foo(x) = x + 2
   ex = :(($foo)(bar, 2, pazz))

--- a/test/egraphs/ematch.jl
+++ b/test/egraphs/ematch.jl
@@ -11,48 +11,48 @@ b = OptBuffer{UInt128}(10)
   r = @rule 2 --> true
   g = EGraph(2)
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 end
 
 @testset "Composite Ground Terms" begin
   r = @rule f(2, 3) --> true
   g = EGraph(:(f(2, 3)))
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
-  @test r.ematcher!(g, 0, Id(1), r.ematcher_stack, b) == 0
-  @test r.ematcher!(g, 0, Id(2), r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
+  @test r.ematcher!(g, 0, Id(1), r.stack, b) == 0
+  @test r.ematcher!(g, 0, Id(2), r.stack, b) == 0
 
   g = EGraph(:(f(2, 4)))
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 0
-  @test r.ematcher!(g, 0, Id(1), r.ematcher_stack, b) == 0
-  @test r.ematcher!(g, 0, Id(2), r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 0
+  @test r.ematcher!(g, 0, Id(1), r.stack, b) == 0
+  @test r.ematcher!(g, 0, Id(2), r.stack, b) == 0
 
 
   r = @rule f(2, h(3, 4)) --> true
   g = EGraph(:(f(2, h(3, 4))))
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
-  @test r.ematcher!(g, 0, Id(1), r.ematcher_stack, b) == 0
-  @test r.ematcher!(g, 0, Id(2), r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
+  @test r.ematcher!(g, 0, Id(1), r.stack, b) == 0
+  @test r.ematcher!(g, 0, Id(2), r.stack, b) == 0
 end
 
 @testset "Pattern Variables" begin
   g = EGraph(:(f(2, 1)))
   r = @rule ~a --> true
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
-  @test r.ematcher!(g, 0, Id(1), r.ematcher_stack, b) == 1
-  @test r.ematcher!(g, 0, Id(2), r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
+  @test r.ematcher!(g, 0, Id(1), r.stack, b) == 1
+  @test r.ematcher!(g, 0, Id(2), r.stack, b) == 1
 end
 
 @testset "Type Assertions" begin
   r = @rule ~a::Int --> true
   g = EGraph(:(f(2, 1)))
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 0
 
   g = EGraph(:3)
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 
   new_id = addexpr!(g, :f)
   union!(g, g.root, new_id)
@@ -60,7 +60,7 @@ end
   new_id = addexpr!(g, 4)
   union!(g, g.root, new_id)
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 2
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 2
 end
 
 @testset "Predicate Assertions" begin
@@ -76,13 +76,13 @@ end
     end
 
   g = EGraph(:(f(2, 1)))
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 0
 
   g = EGraph(:2)
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 
   g = EGraph(:3)
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 0
 
   new_id = addexpr!(g, :f)
   union!(g, g.root, new_id)
@@ -90,7 +90,7 @@ end
   new_id = addexpr!(g, 4)
   union!(g, g.root, new_id)
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 end
 
 
@@ -98,18 +98,18 @@ end
   g = EGraph(:(f(2, 1)))
   r = @rule f(2, ~a) --> true
 
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
-  @test r.ematcher!(g, 0, Id(1), r.ematcher_stack, b) == 0
-  @test r.ematcher!(g, 0, Id(2), r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
+  @test r.ematcher!(g, 0, Id(1), r.stack, b) == 0
+  @test r.ematcher!(g, 0, Id(2), r.stack, b) == 0
 
   r = @rule f(~a, ~a) --> true
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 0
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 0
 
   g = EGraph(:(f(2, 2)))
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 
   g = EGraph(:(f(h(3, 4), h(3, 4))))
-  @test r.ematcher!(g, 0, g.root, r.ematcher_stack, b) == 1
+  @test r.ematcher!(g, 0, g.root, r.stack, b) == 1
 end
 
 

--- a/test/integration/taylor.jl
+++ b/test/integration/taylor.jl
@@ -1,4 +1,4 @@
-using Metatheory
+using Metatheory, Test
 
 struct Σ end
 

--- a/test/tutorials/while_interpreter.jl
+++ b/test/tutorials/while_interpreter.jl
@@ -203,8 +203,10 @@ end
 # `store(a, 5)` will store the value 5 in the `a` variable inside the program's memory.
 
 write_mem = @theory sym val σ begin
-  (store(sym::Symbol, val), σ) => (σ[sym] = eval_if(val, σ);
-  σ)
+  (store(sym::Symbol, val), σ) => begin
+    σ[sym] = eval_if(val, σ)
+    σ
+  end
 end
 
 # ## While loops and sequential computation.

--- a/test/tutorials/while_interpreter.jl
+++ b/test/tutorials/while_interpreter.jl
@@ -160,7 +160,7 @@ eval_bool(ex, mem) = strategy(bool_rules)(:($ex, $mem))
     eval_bool(:((false || false) || !(false || false)), Mem(:x => 2)) == true
     eval_bool(:((2 < 3) && (3 < 4)), Mem(:x => 2)) == true
     eval_bool(:((2 < x) || !(3 < 4)), Mem(:x => 2)) == false
-    eval_bool(:((2 < x) || !(3 < 4)), Mem(:x => 4)) == true
+    eval_bool(:((2 < x)), Mem(:x => 4)) == true
   ],
 )
 


### PR DESCRIPTION
Change base to `ale/3.0` after tests green

Compile classical rewriting matchers as functions, same style as `ematch_compiler`.

Basically 

```julia
julia> r = @rule f(~~x, 3, ~~y, 5, ~~z, 7) => (~~x, ~~y, ~~z)
f(~x..., 3, ~y..., 5, ~z..., 7) => (x, y, z)

julia> @btime  r(:(f(1,2,2,3,4,4,5,6,7,7)))
  472.199 ns (14 allocations: 944 bytes)
(Any[1, 2, 2], Any[4, 4], Any[6, 7])
```

Compared to SU:
```julia
julia> r = SymbolicUtils.@rule f(~~x, 3, ~~y, 5, ~~z, 7) => (~~x, ~~y, ~~z)
       t = term(f, 1, 2, 2, 3, 4, 4, 5, 6, 7, 7)

       @btime r(t)
  2.019 μs (111 allocations: 4.83 KiB)
(Any[1, 2, 2], Any[4, 4], Any[6, 7])
```

cc @shashi @ChrisRackauckas 