### PR TITLE
fix typos

### DIFF
--- a/docs/src/egraphs.md
+++ b/docs/src/egraphs.md
@@ -137,7 +137,7 @@ Given a starting e-graph `g`, a set of rewrite rules `t` and some parameters `p`
 * For each rule in `t`, search through the e-graph for l.h.s.
 * For each match produced, apply the rewrite
 * Do a bottom-up traversal of the e-graph to rebuild the congruence closure
-* If the e-graph hasn’t changed from last iteration, it has saturated. If so, halt saturation.
+* If the e-graph hasn't changed from last iteration, it has saturated. If so, halt saturation.
 * Loop at most n times.
 
 Note that knowing if an expression with a set of rules saturates an e-graph or never terminates

--- a/src/Rewriters.jl
+++ b/src/Rewriters.jl
@@ -13,7 +13,7 @@ rewriters.
 - `RestartedChain(itr)` like `Chain(itr)` but restarts from the first rewriter once on the
    first successful application of one of the chained rewriters.
 - `IfElse(cond, rw1, rw2)` runs the `cond` function on the input, applies `rw1` if cond
-   returns true, `rw2` if it retuns false
+   returns true, `rw2` if it returns false
 - `If(cond, rw)` is the same as `IfElse(cond, rw, Empty())`
 - `Prewalk(rw; threaded=false, thread_cutoff=100)` returns a rewriter which does a pre-order
    traversal of a given expression and applies the rewriter `rw`. Note that if

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -240,10 +240,10 @@ Creates a `RewriteRule` object. A rule object is callable, and takes an
 expression and rewrites it if it matches the LHS pattern to the RHS pattern,
 returns `nothing` otherwise. The rule language is described below.
 
-LHS can be any possibly nested function call expression where any of the arugments can
+LHS can be any possibly nested function call expression where any of the arguments can
 optionally be a Slot (`~x`) or a Segment (`~x...`) (described below).
 
-SLOTS is an optional list of symbols to be interpeted as slots or segments
+SLOTS is an optional list of symbols to be interpreted as slots or segments
 directly (without using `~`).  To declare slots for several rules at once, see
 the `@slots` macro.
 

--- a/src/match_compiler.jl
+++ b/src/match_compiler.jl
@@ -25,7 +25,7 @@ function match_compile(p::AbstractPat, pvars)
 
   state = MatchCompilerState(; pvars_bound = fill(false, npvars))
 
-  # Tree cordinates are a vector of integers.
+  # Tree coordinates are a vector of integers.
   # Each index `i` in the vector corresponds to the depth of the term 
   # Each value `n` at index `i` selects the `n`-th children of the term at depth i
   # Example: in f(x, g(y, k, h(z))), to get z the coordinate is [2,3,1]

--- a/test/tutorials/lambda_theory.jl
+++ b/test/tutorials/lambda_theory.jl
@@ -4,7 +4,7 @@ using Metatheory, Test, TermInterface
 #
 # This tutorial demonstrates how to implement a simple lambda calculus in Metatheory.
 # Importantly, it shows a practical example of [*e-graph analysis*](/egraphs/#EGraph-Analyses).
-# The three building blocks of lambda caluclus are *variables*, $\lambda$-functions, and *function
+# The three building blocks of lambda calculus are *variables*, $\lambda$-functions, and *function
 # application*, which we can implement as subtypes of an abstract `LambdaExpr`ession:
 
 abstract type LambdaExpr end


### PR DESCRIPTION
> Can you please target `ale/3.0` branch? 

@0x0f0f0f 

replaces `227`( Closed)

a single U+2019 character found in the repo

for consistency it was replaced with U+0027