### PR TITLE
Fix hash collisions in e-graph saturation

### DIFF
--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -26,7 +26,7 @@ isground(p::AbstractPat) = false
 struct PatLiteral <: AbstractPat
   value
   n::VecExpr
-  PatLiteral(val) = new(val, Id[0, 0, 0, hash(val)])
+  PatLiteral(val) = new(val, VecExpr(Id[0, 0, 0, hash(val)]))
 end
 
 PatLiteral(p::AbstractPat) = throw(DomainError(p, "Cannot construct a pattern literal of another pattern object."))

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -29,25 +29,32 @@ export Id,
 const Id = UInt64
 
 """
-    const VecExpr = Vector{Id}
+    struct VecExpr
+      data::Vector{Id}
+    end
 
-An e-node is a `Vector{Id}` where:
+An e-node is represented by `Vector{Id}` where:
 * Position 1 stores the hash of the `VecExpr`.
 * Position 2 stores the bit flags (`isexpr` or `iscall`).
 * Position 3 stores the signature
 * Position 4 stores the hash of the `head` (if `isexpr`) or node value in the e-graph constants.
 * The rest of the positions store the e-class ids of the children nodes.
+
+The expression is represented as an array of integers to improve performance.
+The hash value for the VecExpr is cached in the first position for faster lookup performance in dictionaries.
 """
-const VecExpr = Vector{Id}
+struct VecExpr
+  data::Vector{Id}
+end
 
 const VECEXPR_FLAG_ISTREE = 0x01
 const VECEXPR_FLAG_ISCALL = 0x10
 const VECEXPR_META_LENGTH = 4
 
-@inline v_flags(n::VecExpr)::Id = @inbounds n[2]
-@inline v_unset_flags!(n::VecExpr) = @inbounds (n[2] = 0)
+@inline v_flags(n::VecExpr)::Id = @inbounds n.data[2]
+@inline v_unset_flags!(n::VecExpr) = @inbounds (n.data[2] = 0)
 @inline v_check_flags(n::VecExpr, flag::Id)::Bool = !iszero(v_flags(n) & flags)
-@inline v_set_flag!(n::VecExpr, flag)::Id = @inbounds (n[2] = n[2] | flag)
+@inline v_set_flag!(n::VecExpr, flag)::Id = @inbounds (n.data[2] = n.data[2] | flag)
 
 """Returns `true` if the e-node ID points to a an expression tree."""
 @inline v_isexpr(n::VecExpr)::Bool = !iszero(v_flags(n) & VECEXPR_FLAG_ISTREE)
@@ -56,54 +63,62 @@ const VECEXPR_META_LENGTH = 4
 @inline v_iscall(n::VecExpr)::Bool = !iszero(v_flags(n) & VECEXPR_FLAG_ISCALL)
 
 """Number of children in the e-node."""
-@inline v_arity(n::VecExpr)::Int = length(n) - VECEXPR_META_LENGTH
+@inline v_arity(n::VecExpr)::Int = length(n.data) - VECEXPR_META_LENGTH
 
 """
 Compute the hash of a `VecExpr` and store it as the first element.
 """
 @inline function v_hash!(n::VecExpr)::Id
-  if iszero(n[1])
-    n[1] = hash(@view n[2:end])
+  if iszero(n.data[1])
+    n.data[1] = hash(@view n.data[2:end])
   else
     # h = hash(@view n[2:end])
     # @assert h == n[1]
-    n[1]
+    n.data[1]
   end
 end
 
 """The hash of the e-node."""
-@inline v_hash(n::VecExpr)::Id = @inbounds n[1]
+@inline v_hash(n::VecExpr)::Id = @inbounds n.data[1]
+Base.hash(n::VecExpr) = v_hash(n) # IdKey not necessary here
+Base.:(==)(a::VecExpr, b::VecExpr) = (@view a.data[2:end]) == (@view b.data[2:end])
 
 """Set e-node hash to zero."""
-@inline v_unset_hash!(n::VecExpr)::Id = @inbounds (n[1] = Id(0))
+@inline v_unset_hash!(n::VecExpr)::Id = @inbounds (n.data[1] = Id(0))
 
 """E-class IDs of the children of the e-node."""
-@inline v_children(n::VecExpr) = @view n[(VECEXPR_META_LENGTH + 1):end]
+@inline v_children(n::VecExpr) = @view n.data[(VECEXPR_META_LENGTH + 1):end]
 
-@inline v_signature(n::VecExpr)::Id = @inbounds n[3]
+@inline v_signature(n::VecExpr)::Id = @inbounds n.data[3]
 
-@inline v_set_signature!(n::VecExpr, sig::Id) = @inbounds (n[3] = sig)
+@inline v_set_signature!(n::VecExpr, sig::Id) = @inbounds (n.data[3] = sig)
 
 "The constant ID of the operation of the e-node, or the e-node ."
-@inline v_head(n::VecExpr)::Id = @inbounds n[VECEXPR_META_LENGTH]
+@inline v_head(n::VecExpr)::Id = @inbounds n.data[VECEXPR_META_LENGTH]
 
 "Update the E-Node operation ID."
-@inline v_set_head!(n::VecExpr, h::Id) = @inbounds (n[VECEXPR_META_LENGTH] = h)
+@inline v_set_head!(n::VecExpr, h::Id) = @inbounds (n.data[VECEXPR_META_LENGTH] = h)
 
 """Construct a new, empty `VecExpr` with `len` children."""
 @inline function v_new(len::Int)::VecExpr
-  n = Vector{Id}(undef, len + VECEXPR_META_LENGTH)
+  n = VecExpr(Vector{Id}(undef, len + VECEXPR_META_LENGTH))
   v_unset_hash!(n)
   v_unset_flags!(n)
   n
 end
 
-@inline v_children_range(n::VecExpr) = ((VECEXPR_META_LENGTH + 1):length(n))
+@inline v_children_range(n::VecExpr) = ((VECEXPR_META_LENGTH + 1):length(n.data))
 
 
 v_pair(a::UInt64, b::UInt64) = UInt128(a) << 64 | b
 v_pair_first(p::UInt128)::UInt64 = UInt64(p >> 64)
 v_pair_last(p::UInt128)::UInt64 = UInt64(p & 0xffffffffffffffff)
 
+@inline Base.length(n::VecExpr) = length(n.data)
+@inline Base.getindex(n::VecExpr, i) = n.data[i]
+@inline Base.setindex!(n::VecExpr, val, i) = n.data[i] = val
+@inline Base.copy(n::VecExpr) = VecExpr(copy(n.data))
+@inline Base.lastindex(n::VecExpr) = lastindex(n.data)
+@inline Base.firstindex(n::VecExpr) = firstindex(n.data)
 
 end


### PR DESCRIPTION
Fix hash collision in EGraph.memo by changing the dictionary key to VecExpr.  Create struct for VecExpr and wrap Vector{Id}.