### PR TITLE
Fix comparison with rule application result and missing iterate method for OptBuffer

### DIFF
--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -36,7 +36,7 @@ An `EClass` is an equivalence class of terms.
 
 The children and parent nodes are stored as [`VecExpr`](@ref)s for performance, which
 means that without a reference to the [`EGraph`](@ref) object we cannot re-build human-readable terms
-they represent. The [`EGraph`](@ref) itself comes with pretty printing for humean-readable terms.
+they represent. The [`EGraph`](@ref) itself comes with pretty printing for human-readable terms.
 """
 struct EClass{D}
   id::Id

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -252,7 +252,7 @@ function eqsat_apply!(
       break
     end
 
-    res.l !== 0 && res.r !== 0 && union!(g, res.l, res.r)
+    !iszero(res.l) && !iszero(res.r) && union!(g, res.l, res.r)
   end
   if params.goal(g)
     @debug "Goal reached"

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -183,7 +183,7 @@ function apply_rule!(
     RuleApplicationResult(:nothing, 0, 0)
   elseif rule.op === (|>) # DynamicRule
     r = rule.right(id, g, (instantiate_actual_param!(bindings, g, i) for i in 1:length(rule.patvars))...)
-    isnothing(r) && return RuleApplicationResult(nothing, 0, 0)
+    isnothing(r) && return RuleApplicationResult(:nothing, 0, 0)
     rcid = addexpr!(g, r)
     RuleApplicationResult(:nothing, rcid, id)
   else

--- a/src/optbuffer.jl
+++ b/src/optbuffer.jl
@@ -34,3 +34,4 @@ end
 Base.isempty(b::OptBuffer{T}) where {T} = b.i === 0
 Base.empty!(b::OptBuffer{T}) where {T} = (b.i = 0)
 @inline Base.length(b::OptBuffer{T}) where {T} = b.i
+Base.iterate(b::OptBuffer{T}, i=1) where {T} = iterate(b.v[1:b.i], i)

--- a/test/egraphs/analysis.jl
+++ b/test/egraphs/analysis.jl
@@ -111,3 +111,15 @@ end
 
 end
 
+
+
+@testset "Conditional Dynamic Rule" begin
+  g = EGraph{Expr,NumberFoldAnalysis}()
+
+  theo_dyn_cond = @theory a begin
+    a => !isnothing(a.data) ? a.data.n : nothing # awkward rule to trigger a certain branch in saturation.jl
+  end
+
+  @test !test_equality(theo_dyn_cond, :x, :y, :z; g)
+  @test !test_equality(theo_dyn_cond, 0, 1, 2; g)
+end


### PR DESCRIPTION
zero(Id) !== 0    is true because 0 and zero(Id) are different types. 