### PR TITLE
Fix tests to work in the standard test workflow

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Metatheory = "e9d8d322-4543-424a-9be4-0cc815abe26c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ function test(file::String)
   end
 end
 
-allscripts(dir) = [joinpath(@__DIR__, dir, x) for x in readdir(dir) if endswith(x, ".jl")]
+allscripts(dir) =
+  [joinpath(@__DIR__, dir, x) for x in readdir(joinpath(@__DIR__, dir)) if endswith(x, ".jl")]
 
 const TEST_FILES = [
   allscripts("unit")


### PR DESCRIPTION
The standard test workflow for all Julia projects I've
seen is:

(to initialize)
> julia --project=test
> ]instantiate
> ]develop .
> Ctrl-D

(to run tests)
> julia --project=test test/runtests.jl

This commit makes sure that the Metatheory tests can be run in this
manner, so that developers don't have to install Documenter,
SafeTestsets and TermInterface globally.