### PR TITLE
Fix enode memoization

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,9 +1,6 @@
 name: Benchmark pull request
 
-on:
-  pull_request:
-    branches:
-      - master
+on: [pull_request]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -224,13 +224,11 @@ Returns the canonical e-class id for a given e-class.
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
 function canonicalize!(g::EGraph, n::VecExpr)
-  v_isexpr(n) || @goto ret
-  for i in (VECEXPR_META_LENGTH + 1):length(n)
-    @inbounds n[i] = find(g, n[i])
+  if v_isexpr(n)
+    for i in (VECEXPR_META_LENGTH + 1):length(n)
+      @inbounds n[i] = find(g, n[i])
+    end
   end
-  v_unset_hash!(n)
-  @label ret
-  v_hash!(n)
   n
 end
 
@@ -320,7 +318,7 @@ function addexpr!(g::EGraph, se)::Id
     end
     n
   else # constant enode
-    VecExpr(Id[Id(0), Id(0), Id(0), add_constant!(g, e)])
+    VecExpr(Id[Id(0), Id(0), add_constant!(g, e)])
   end
   id = add!(g, n, false)
   return id
@@ -489,7 +487,7 @@ for more details.
 function rebuild!(g::EGraph)
   n_unions = process_unions!(g)
   trimmed_nodes = rebuild_classes!(g)
-  @assert check_memo(g)
+  # @assert check_memo(g)
   # @assert check_analysis(g)
   g.clean = true
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -223,22 +223,6 @@ Returns the canonical e-class id for a given e-class.
 
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
-# function canonicalize(g::EGraph, n::VecExpr)::VecExpr
-#   if !v_isexpr(n)
-#     v_hash!(n)
-#     return n
-#   end
-#   l = v_arity(n)
-#   new_n = v_new(l)
-#   v_set_flag!(new_n, v_flags(n))
-#   v_set_head!(new_n, v_head(n))
-#   for i in v_children_range(n)
-#     @inbounds new_n[i] = find(g, n[i])
-#   end
-#   v_hash!(new_n)
-#   new_n
-# end
-
 function canonicalize!(g::EGraph, n::VecExpr)
   v_isexpr(n) || @goto ret
   for i in (VECEXPR_META_LENGTH + 1):length(n)
@@ -252,7 +236,6 @@ end
 
 function lookup(g::EGraph, n::VecExpr)::Id
   canonicalize!(g, n)
-  h = IdKey(v_hash(n))
 
   haskey(g.memo, n) ? find(g, g.memo[n]) : 0
 end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -473,9 +473,8 @@ function check_memo(g::EGraph)::Bool
   for (id, class) in g.classes
     @assert id.val == class.id
     for node in class.nodes
-      if haskey(test_memo, node)
-        old_id = test_memo[node]
-        test_memo[node] = id.val
+      old_id = get!(test_memo, node, id.val)
+      if old_id != id.val
         @assert find(g, old_id) == find(g, id.val) "Unexpected equivalence $node $(g[find(g, id.val)].nodes) $(g[find(g, old_id)].nodes)"
       end
     end
@@ -483,7 +482,7 @@ function check_memo(g::EGraph)::Bool
 
   for (node, id) in test_memo
     @assert id == find(g, id)
-    @assert id == find(g, g.memo[node])
+    @assert id == find(g, g.memo[node]) "Entry for $node at $id in test_memo was incorrect."
   end
 
   true
@@ -507,7 +506,7 @@ for more details.
 function rebuild!(g::EGraph)
   n_unions = process_unions!(g)
   trimmed_nodes = rebuild_classes!(g)
-  # @assert check_memo(g)
+  @assert check_memo(g)
   # @assert check_analysis(g)
   g.clean = true
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -235,7 +235,8 @@ end
 function lookup(g::EGraph, n::VecExpr)::Id
   canonicalize!(g, n)
 
-  haskey(g.memo, n) ? find(g, g.memo[n]) : 0
+  id = get(g.memo, n, zero(Id))
+  iszero(id) ? id : find(g, id)
 end
 
 
@@ -253,9 +254,10 @@ Inserts an e-node in an [`EGraph`](@ref)
 """
 function add!(g::EGraph{ExpressionType,Analysis}, n::VecExpr, should_copy::Bool)::Id where {ExpressionType,Analysis}
   canonicalize!(g, n)
-
-  haskey(g.memo, n) && return g.memo[n]
-
+  
+  id = get(g.memo, n, zero(Id))
+  iszero(id) || return id
+  
   if should_copy
     n = copy(n)
   end
@@ -412,9 +414,8 @@ function process_unions!(g::EGraph{ExpressionType,AnalysisType})::Int where {Exp
     while !isempty(g.pending)
       (node::VecExpr, eclass_id::Id) = pop!(g.pending)
       canonicalize!(g, node)
-      if haskey(g.memo, node)
-        old_class_id = g.memo[node]
-        g.memo[node] = eclass_id
+      old_class_id = get!(g.memo, node, eclass_id)
+      if old_class_id != eclass_id
         did_something = union!(g, old_class_id, eclass_id)
         # TODO unique! can node dedup be moved here? compare performance
         # did_something && unique!(g[eclass_id].nodes)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -488,7 +488,7 @@ for more details.
 function rebuild!(g::EGraph)
   n_unions = process_unions!(g)
   trimmed_nodes = rebuild_classes!(g)
-  # @assert check_memo(g)
+  @assert check_memo(g)
   # @assert check_analysis(g)
   g.clean = true
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -302,28 +302,21 @@ function addexpr!(g::EGraph, se)::Id
   se isa EClass && return se.id
   e = preprocess(se)
 
-  n = if isexpr(e)
-    args = iscall(e) ? arguments(e) : children(e)
-    ar = length(args)
-    n = v_new(ar)
-    v_set_flag!(n, VECEXPR_FLAG_ISTREE)
-    iscall(e) && v_set_flag!(n, VECEXPR_FLAG_ISCALL)
+  isexpr(e) || return add!(g, VecExpr(Id[Id(0), Id(0), add_constant!(g, e)]), false) # constant enode
 
-    h = iscall(e) ? operation(e) : head(e)
-    v_set_head!(n, add_constant!(g, h))
-
-    # get the signature from op and arity 
-    v_set_signature!(n, hash(maybe_quote_operation(h), hash(ar)))
-
-    for i in v_children_range(n)
-      @inbounds n[i] = addexpr!(g, args[i - VECEXPR_META_LENGTH])
-    end
-    n
-  else # constant enode
-    VecExpr(Id[Id(0), Id(0), add_constant!(g, e)])
+  args = iscall(e) ? arguments(e) : children(e)
+  ar = length(args)
+  n = v_new(ar)
+  v_set_flag!(n, VECEXPR_FLAG_ISTREE)
+  iscall(e) && v_set_flag!(n, VECEXPR_FLAG_ISCALL)
+  h = iscall(e) ? operation(e) : head(e)
+  v_set_head!(n, add_constant!(g, h))
+  # get the signature from op and arity 
+  v_set_signature!(n, hash(maybe_quote_operation(h), hash(ar)))
+  for i in v_children_range(n)
+    @inbounds n[i] = addexpr!(g, args[i - VECEXPR_META_LENGTH])
   end
-  id = add!(g, n, false)
-  return id
+  add!(g, n, false)
 end
 
 """
@@ -488,7 +481,7 @@ for more details.
 function rebuild!(g::EGraph)
   n_unions = process_unions!(g)
   trimmed_nodes = rebuild_classes!(g)
-  @assert check_memo(g)
+  # @assert check_memo(g)
   # @assert check_analysis(g)
   g.clean = true
 

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -26,7 +26,7 @@ isground(p::AbstractPat) = false
 struct PatLiteral <: AbstractPat
   value
   n::VecExpr
-  PatLiteral(val) = new(val, VecExpr(Id[0, 0, 0, hash(val)]))
+  PatLiteral(val) = new(val, VecExpr(Id[0, 0, hash(val)]))
 end
 
 PatLiteral(p::AbstractPat) = throw(DomainError(p, "Cannot construct a pattern literal of another pattern object."))


### PR DESCRIPTION
Metatheory uses caching of hash values for enodes (in VecExpr) presumably to reduce the number of hash value calculations. At the same time we find code such as ```haskey(g.memo, n) ? g.memo[n] : 0``` which does two lookups in the ```memo``` dictionary where only one is necessary.

Much more critical is that nodes are mutated after they are added added to memo, whereby the hash value is changed. This is a bug because the lookup of a node (```g.memo[n]```) will fail even if the node is contained in the dictionary. The reason is that the lookup will use the new hash value to find the node while the location of the node in the hashtable is based on the old hash value. This bug is detected by ```check_memo()```. 

This bug has been introduced by myself in #229 , but even before that the memoization was incorrect, because of the issue of hash collisions, and hash-values of updated nodes not begin updated in memo. 

I believe it will be difficult, if not impossible, to combine caching of hash-values with mutable nodes in the memo dictionary. But I'm open for suggestions. 