### PR TITLE
Fix hashing and memoization of enodes (VecExpr)

### DIFF
--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -271,17 +271,17 @@ function add!(g::EGraph{ExpressionType,Analysis}, n::VecExpr, should_copy::Bool)
 
   if v_isexpr(n)
     for c_id in v_children(n)
-      addparent!(g.classes[IdKey(c_id)], n, id)
+      addparent!(g.classes[IdKey(c_id)], copy(n), id)
     end
   end
 
-  g.memo[n] = id
+  g.memo[copy(n)] = id
 
   add_class_by_op(g, n, id)
   eclass = EClass{Analysis}(id, VecExpr[n], Pair{VecExpr,Id}[], make(g, n))
   g.classes[IdKey(id)] = eclass
   modify!(g, eclass)
-  push!(g.pending, n => id)
+  push!(g.pending, copy(n) => id)
 
   return id
 end
@@ -412,6 +412,7 @@ function process_unions!(g::EGraph{ExpressionType,AnalysisType})::Int where {Exp
   while !isempty(g.pending) || !isempty(g.analysis_pending)
     while !isempty(g.pending)
       (node::VecExpr, eclass_id::Id) = pop!(g.pending)
+      node = copy(node)
       canonicalize!(g, node)
       old_class_id = get!(g.memo, node, eclass_id)
       if old_class_id != eclass_id

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -416,9 +416,8 @@ function process_unions!(g::EGraph{ExpressionType,AnalysisType})::Int where {Exp
     while !isempty(g.pending)
       (node::VecExpr, eclass_id::Id) = pop!(g.pending)
       canonicalize!(g, node)
-      if haskey(g.memo, node)
-        old_class_id = g.memo[node]
-        g.memo[node] = eclass_id
+      old_class_id = get!(g.memo, node, eclass_id)
+      if old_class_id != eclass_id
         did_something = union!(g, old_class_id, eclass_id)
         # TODO unique! can node dedup be moved here? compare performance
         # did_something && unique!(g[eclass_id].nodes)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -72,7 +72,7 @@ end
 function merge_analysis_data!(a::EClass{D}, b::EClass{D})::Tuple{Bool,Bool,Union{D,Nothing}} where {D}
   if !isnothing(a.data) && !isnothing(b.data)
     new_a_data = join(a.data, b.data)
-    (a.data == new_a_data, b.data == new_a_data, new_a_data)
+    (a.data != new_a_data, b.data != new_a_data, new_a_data)
   elseif isnothing(a.data) && !isnothing(b.data)
     # a merged, b not merged
     (true, false, b.data)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -272,17 +272,17 @@ function add!(g::EGraph{ExpressionType,Analysis}, n::VecExpr, should_copy::Bool)
 
   if v_isexpr(n)
     for c_id in v_children(n)
-      addparent!(g.classes[IdKey(c_id)], copy(n), id)
+      addparent!(g.classes[IdKey(c_id)], n, id)
     end
   end
 
-  g.memo[copy(n)] = id
+  g.memo[n] = id
 
   add_class_by_op(g, n, id)
-  eclass = EClass{Analysis}(id, VecExpr[n], Pair{VecExpr,Id}[], make(g, n))
+  eclass = EClass{Analysis}(id, VecExpr[copy(n)], Pair{VecExpr,Id}[], make(g, n))
   g.classes[IdKey(id)] = eclass
   modify!(g, eclass)
-  push!(g.pending, copy(n) => id)
+  push!(g.pending, n => id)
 
   return id
 end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -248,11 +248,8 @@ end
 
 function add_class_by_op(g::EGraph, n, eclass_id)
   key = IdKey(v_signature(n))
-  if haskey(g.classes_by_op, key)
-    push!(g.classes_by_op[key], eclass_id)
-  else
-    g.classes_by_op[key] = [eclass_id]
-  end
+  vec = get!(g.classes_by_op, key, Vector{Id}())
+  push!(vec, eclass_id)
 end
 
 """

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -223,22 +223,6 @@ Returns the canonical e-class id for a given e-class.
 
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
-# function canonicalize(g::EGraph, n::VecExpr)::VecExpr
-#   if !v_isexpr(n)
-#     v_hash!(n)
-#     return n
-#   end
-#   l = v_arity(n)
-#   new_n = v_new(l)
-#   v_set_flag!(new_n, v_flags(n))
-#   v_set_head!(new_n, v_head(n))
-#   for i in v_children_range(n)
-#     @inbounds new_n[i] = find(g, n[i])
-#   end
-#   v_hash!(new_n)
-#   new_n
-# end
-
 function canonicalize!(g::EGraph, n::VecExpr)
   v_isexpr(n) || @goto ret
   for i in (VECEXPR_META_LENGTH + 1):length(n)
@@ -252,7 +236,6 @@ end
 
 function lookup(g::EGraph, n::VecExpr)::Id
   canonicalize!(g, n)
-  h = IdKey(v_hash(n))
 
   haskey(g.memo, n) ? find(g, g.memo[n]) : 0
 end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -224,6 +224,8 @@ Returns the canonical e-class id for a given e-class.
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
 function canonicalize!(g::EGraph, n::VecExpr)
+  orig = copy(n)
+  inmemo = any(entry -> objectid(entry) == objectid(n), keys(g.memo))
   v_isexpr(n) || @goto ret
   for i in (VECEXPR_META_LENGTH + 1):length(n)
     @inbounds n[i] = find(g, n[i])
@@ -231,6 +233,7 @@ function canonicalize!(g::EGraph, n::VecExpr)
   v_unset_hash!(n)
   @label ret
   v_hash!(n)
+  @assert orig == n || !inmemo
   n
 end
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -224,8 +224,8 @@ Returns the canonical e-class id for a given e-class.
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
 function canonicalize!(g::EGraph, n::VecExpr)
-  orig = copy(n)
-  inmemo = any(entry -> objectid(entry) == objectid(n), keys(g.memo))
+  # orig = copy(n)
+  # inmemo = any(entry -> objectid(entry) == objectid(n), keys(g.memo))
   v_isexpr(n) || @goto ret
   for i in (VECEXPR_META_LENGTH + 1):length(n)
     @inbounds n[i] = find(g, n[i])
@@ -233,7 +233,7 @@ function canonicalize!(g::EGraph, n::VecExpr)
   v_unset_hash!(n)
   @label ret
   v_hash!(n)
-  @assert orig == n || !inmemo
+  # @assert orig == n || !inmemo
   n
 end
 
@@ -488,7 +488,7 @@ for more details.
 function rebuild!(g::EGraph)
   n_unions = process_unions!(g)
   trimmed_nodes = rebuild_classes!(g)
-  @assert check_memo(g)
+  # @assert check_memo(g)
   # @assert check_analysis(g)
   g.clean = true
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -225,8 +225,6 @@ Returns the canonical e-class id for a given e-class.
 @inline Base.getindex(g::EGraph, i::Id) = g.classes[IdKey(find(g, i))]
 
 function canonicalize!(g::EGraph, n::VecExpr)
-  # orig = copy(n)
-  # inmemo = any(entry -> objectid(entry) == objectid(n), keys(g.memo))
   v_isexpr(n) || @goto ret
   for i in (VECEXPR_META_LENGTH + 1):length(n)
     @inbounds n[i] = find(g, n[i])
@@ -234,7 +232,6 @@ function canonicalize!(g::EGraph, n::VecExpr)
   v_unset_hash!(n)
   @label ret
   v_hash!(n)
-  # @assert orig == n || !inmemo
   n
 end
 

--- a/src/EGraphs/uniquequeue.jl
+++ b/src/EGraphs/uniquequeue.jl
@@ -12,7 +12,8 @@ end
 UniqueQueue{T}() where {T} = UniqueQueue{T}(Set{T}(), T[])
 
 function Base.push!(uq::UniqueQueue{T}, x::T) where {T}
-  if !in!(x, uq.set)
+  if !(x in uq.set)
+    push!(uq.set, x)
     push!(uq.vec, x)
   end
 end
@@ -30,15 +31,3 @@ function Base.pop!(uq::UniqueQueue{T}) where {T}
 end
 
 Base.isempty(uq::UniqueQueue) = isempty(uq.vec)
-
-# Helper for push!()
-# checks if x is contained in s and adds x if it is not, using a single hash call and lookup
-# available from Julia 1.11
-function in!(x::T, s::Set{T}) where {T}
-  idx, sh = Base.ht_keyindex2_shorthash!(s.dict, x)
-  idx > 0 && return true
-  Base._setindex!(s.dict, nothing, x, -idx, sh)
-  
-  false
-end
-

--- a/src/EGraphs/uniquequeue.jl
+++ b/src/EGraphs/uniquequeue.jl
@@ -12,8 +12,17 @@ end
 UniqueQueue{T}() where {T} = UniqueQueue{T}(Set{T}(), T[])
 
 function Base.push!(uq::UniqueQueue{T}, x::T) where {T}
-  if !(x in uq.set)
-    push!(uq.set, x)
+  # checks if x is contained in s and adds x if it is not, using a single hash call and lookup
+  # available from Julia 1.11
+  function in!(x::T, s::Set)
+    idx, sh = Base.ht_keyindex2_shorthash!(s.dict, x)
+    idx > 0 && return true
+    _setindex!(s.dict, nothing, x, -idx, sh)
+    
+    false
+  end
+
+  if !in!(x, uq.set)
     push!(uq.vec, x)
   end
 end

--- a/src/EGraphs/uniquequeue.jl
+++ b/src/EGraphs/uniquequeue.jl
@@ -17,7 +17,7 @@ function Base.push!(uq::UniqueQueue{T}, x::T) where {T}
   function in!(x::T, s::Set)
     idx, sh = Base.ht_keyindex2_shorthash!(s.dict, x)
     idx > 0 && return true
-    _setindex!(s.dict, nothing, x, -idx, sh)
+    Base._setindex!(s.dict, nothing, x, -idx, sh)
     
     false
   end

--- a/src/EGraphs/uniquequeue.jl
+++ b/src/EGraphs/uniquequeue.jl
@@ -12,16 +12,6 @@ end
 UniqueQueue{T}() where {T} = UniqueQueue{T}(Set{T}(), T[])
 
 function Base.push!(uq::UniqueQueue{T}, x::T) where {T}
-  # checks if x is contained in s and adds x if it is not, using a single hash call and lookup
-  # available from Julia 1.11
-  function in!(x::T, s::Set)
-    idx, sh = Base.ht_keyindex2_shorthash!(s.dict, x)
-    idx > 0 && return true
-    Base._setindex!(s.dict, nothing, x, -idx, sh)
-    
-    false
-  end
-
   if !in!(x, uq.set)
     push!(uq.vec, x)
   end
@@ -40,3 +30,15 @@ function Base.pop!(uq::UniqueQueue{T}) where {T}
 end
 
 Base.isempty(uq::UniqueQueue) = isempty(uq.vec)
+
+# Helper for push!()
+# checks if x is contained in s and adds x if it is not, using a single hash call and lookup
+# available from Julia 1.11
+function in!(x::T, s::Set{T}) where {T}
+  idx, sh = Base.ht_keyindex2_shorthash!(s.dict, x)
+  idx > 0 && return true
+  Base._setindex!(s.dict, nothing, x, -idx, sh)
+  
+  false
+end
+

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -80,7 +80,7 @@ end
 
 """The hash of the e-node."""
 @inline v_hash(n::VecExpr)::Id = @inbounds n.data[1]
-Base.hash(n::VecExpr) = v_hash(n) # IdKey not necessary here
+Base.hash(n::VecExpr, h::UInt) = hash(v_hash(n), h) # IdKey not necessary here
 Base.:(==)(a::VecExpr, b::VecExpr) = (@view a.data[2:end]) == (@view b.data[2:end])
 
 """Set e-node hash to zero."""


### PR DESCRIPTION
This new PR fixes an issue with memoization of enodes, whereby enodes in the memo dictionary are updated, invalidating their hash value. 
Additional fixes and improvements:
- Fix the ```check_memo()``` function to actually check memo
- Fix the implementation of ```Base.hash``` for ```VecExpr```
- Improve efficiency of dictionary lookups by using ```get() / get!()```

(related PR:  #238 has additional changes to remove caching of hash values for VecExpr)