### PR TITLE
Change implementation of BackoffScheduler to match egg.

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -43,13 +43,13 @@ simpl1_math = :(a + b + (0 * c) + d)
 SUITE["basic_maths"]["simpl1"] = @benchmarkable (@assert :(a + b + d) == simplify(
   $simpl1_math,
   $maths_theory,
-  $(SaturationParams(; timer = false)),
+  $(SaturationParams(enodelimit=15000, timeout=8, timer = false)),
   postprocess_maths,
 ))
 
 simpl2_math = :(0 + (1 * foo) * 0 + (a * 0) + a)
 SUITE["basic_maths"]["simpl2"] =
-  @benchmarkable (@assert :a == simplify($simpl2_math, $maths_theory, $(SaturationParams()), postprocess_maths))
+  @benchmarkable (@assert :a == simplify($simpl2_math, $maths_theory, $(SaturationParams(enodelimit=15000, timeout=8, timer=false)), postprocess_maths))
 
 
 # ==================================================================
@@ -60,7 +60,7 @@ ex_orig = :(((p ⟹ q) && (r ⟹ s) && (p || r)) ⟹ (q || s))
 ex_logic = rewrite(ex_orig, impl)
 
 SUITE["prop_logic"]["rewrite"] = @benchmarkable rewrite($ex_orig, $impl)
-SUITE["prop_logic"]["prove1"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_logic, 3, 6))
+SUITE["prop_logic"]["prove1"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_logic, 2, 6))
 
 ex_demorgan = :(!(p || q) == (!p && !q))
 SUITE["prop_logic"]["demorgan"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_demorgan))

--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -1,4 +1,4 @@
-# Sketch function for basic iterative saturation and extraction 
+# Sketch function for basic iterative saturation and extraction
 function prove(
   t,
   ex,

--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -19,9 +19,6 @@ function prove(
     params.goal = (g::EGraph) -> in_same_class(g, ids...)
     saturate!(g, t, params)
     ex = extract!(g, astsize)
-    if !TermInterface.isexpr(ex)
-      return ex
-    end
   end
   return ex
 end

--- a/src/EGraphs/Schedulers.jl
+++ b/src/EGraphs/Schedulers.jl
@@ -184,7 +184,7 @@ function search_matches!(s::BackoffScheduler,
   if n_matches > threshold
     ban_length = s.ban_length << times_banned
     banned_until = s.curr_iter + ban_length
-    @debug "Banning $rule (banned $times_banned x) for $ban_length iterations (threshold: $threshold < $n_matches matches)."
+    @debug "Banning $rule (banned $times_banned times) for $ban_length iterations (threshold: $threshold < $n_matches matches)."
     s.data[rule_idx] = (times_banned + 1, banned_until)
     # revert matches because the rule could be matched to eclasses only partially
     resize!(ematch_buffer, old_ematch_buffer_size)
@@ -232,7 +232,7 @@ cansaturate(s::FreezingScheduler)::Bool = all(stat -> stat.banned_until < s.curr
 function cansearch!(s::FreezingScheduler, eclass_id)
   stats = s[eclass_id]
   if s.curr_iter < stats.banned_until
-    @debug "Skipping eclass $eclass_id (banned $(stats.times_banned) x) until $(stats.banned_until)."
+    @debug "Skipping eclass $eclass_id (banned $(stats.times_banned) times) until $(stats.banned_until)."
     return false
   end
 
@@ -242,7 +242,7 @@ function cansearch!(s::FreezingScheduler, eclass_id)
     ban_length = stats.ban_length + s.default_eclass_ban_increment * stats.times_banned
     stats.times_banned += 1
     stats.banned_until = s.curr_iter + ban_length
-    @debug "Banning eclass $eclass_id (banned $(stats.times_banned) x) for $ban_length iterations (threshold: $threshold < $len nodes))."
+    @debug "Banning eclass $eclass_id (banned $(stats.times_banned) times) for $ban_length iterations (threshold: $threshold < $len nodes))."
 
     return false
   end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -384,7 +384,6 @@ function rebuild_classes!(g::EGraph)
   end
 
   for (eclass_id, eclass) in g.classes
-    # old_len = length(eclass.nodes)
     for n in eclass.nodes
       canonicalize!(g, n)
     end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -1,13 +1,12 @@
 # Functional implementation of https://egraphs-good.github.io/
 # https://dl.acm.org/doi/10.1145/3434304
 
-
 """
     modify!(eclass::EClass{Analysis})
 
 The `modify!` function for EGraph Analysis can optionally modify the eclass
 `eclass` after it has been analyzed, typically by adding an e-node.
-It should be **idempotent** if no other changes occur to the EClass. 
+It should be **idempotent** if no other changes occur to the EClass.
 (See the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304)).
 """
 function modify! end
@@ -25,7 +24,7 @@ function join end
 """
     make(g::EGraph{ExpressionType, AnalysisType}, n::VecExpr)::AnalysisType where {ExpressionType}
 
-Given an e-node `n`, `make` should return the corresponding analysis value. 
+Given an e-node `n`, `make` should return the corresponding analysis value.
 """
 function make end
 
@@ -284,7 +283,7 @@ end
 
 """
 Extend this function on your types to do preliminary
-preprocessing of a symbolic term before adding it to 
+preprocessing of a symbolic term before adding it to
 an EGraph. Most common preprocessing techniques are binarization
 of n-ary terms and metadata stripping.
 """

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -144,14 +144,12 @@ end
 Instantiate argument for dynamic rule application in e-graph
 """
 function instantiate_actual_param!(bindings, g::EGraph, i)
+  const_hash = v_pair_last(bindings[i])
+  const_hash == 0 || return get_constant(g, const_hash)
+
   ecid = v_pair_first(bindings[i])
-  literal_position = reinterpret(Int, v_pair_last(bindings[i]))
   ecid <= 0 && error("unbound pattern variable")
   eclass = g[ecid]
-  if literal_position > 0
-    @assert !v_isexpr(eclass[literal_position])
-    return get_constant(g, v_head(eclass[literal_position]))
-  end
   return eclass
 end
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -75,7 +75,6 @@ function eqsat_search!(
   empty!(ematch_buffer)
   g.needslock && unlock(g.lock)
 
-
   @debug "SEARCHING"
   for (rule_idx, rule) in enumerate(theory)
     @timeit report.to string(rule_idx) begin

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -78,7 +78,6 @@ function eqsat_search!(
 
   @debug "SEARCHING"
   for (rule_idx, rule) in enumerate(theory)
-    prev_matches = n_matches
     @timeit report.to string(rule_idx) begin
       prev_matches = n_matches
       # don't apply banned rules
@@ -90,24 +89,23 @@ function eqsat_search!(
       ids_left = cached_ids(g, rule.left)
       for i in ids_left
         cansearch(scheduler, rule_idx, i) || continue
-        n_matches += rule.ematcher_left!(g, rule_idx, i, rule.stack, ematch_buffer)
-        inform!(scheduler, rule_idx, i, n_matches)
+        eclass_matches = rule.ematcher_left!(g, rule_idx, i, rule.stack, ematch_buffer)
+        n_matches += eclass_matches
+        inform!(scheduler, rule_idx, i, eclass_matches)
       end
 
       if is_bidirectional(rule)
         ids_right = cached_ids(g, rule.right)
         for i in ids_right
           cansearch(scheduler, rule_idx, i) || continue
-          n_matches += rule.ematcher_right!(g, rule_idx, i, rule.stack, ematch_buffer)
-          inform!(scheduler, rule_idx, i, n_matches)
+          eclass_matches = rule.ematcher_right!(g, rule_idx, i, rule.stack, ematch_buffer)
+          n_matches += eclass_matches
+          inform!(scheduler, rule_idx, i, eclass_matches)
         end
       end
 
       n_matches - prev_matches > 0 && @debug "Rule $rule_idx: $rule produced $(n_matches - prev_matches) matches"
-      # if n_matches - prev_matches > 2 && rule_idx == 2
-      #   @debug buffer_readable(g, old_len)
-      # end
-      inform!(scheduler, rule_idx, n_matches)
+      inform!(scheduler, rule_idx, n_matches - prev_matches)
     end
   end
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -77,14 +77,14 @@ function eqsat_search!(
 
   @debug "SEARCHING"
   for (rule_idx, rule) in enumerate(theory)
+    # don't apply banned rules
+    if !cansearch(scheduler, rule_idx)
+      @debug "$rule is banned"
+      continue
+    end
+
     @timeit report.to string(rule_idx) begin
       prev_matches = n_matches
-      # don't apply banned rules
-      if !cansearch(scheduler, rule_idx)
-        @debug "$rule is banned"
-        continue
-      end
-
       ids_left = cached_ids(g, rule.left)
       for i in ids_left
         cansearch(scheduler, rule_idx, i) || continue

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -326,7 +326,17 @@ end
 
 function yield_expr(patvar_to_addr, direction)
   push_exprs = [
-    :(push!(ematch_buffer, v_pair($(Symbol(:σ, addr)), reinterpret(UInt64, $(Symbol(:enode_idx, addr)) - 1)))) for
+    quote
+      id = $(Symbol(:σ, addr))
+      eclass = g[id]
+      node_idx = $(Symbol(:enode_idx, addr)) - 1
+      if node_idx == 0
+        push!(ematch_buffer, v_pair(id, reinterpret(UInt64, 0)))
+      else
+        n = eclass.nodes[node_idx]
+        push!(ematch_buffer, v_pair(id, v_head(n)))
+      end
+    end for
     addr in patvar_to_addr
   ]
   quote

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -253,12 +253,13 @@ function check_var_expr(addr, predicate::Function)
   quote
     eclass = g[$(Symbol(:σ, addr))]
     if ($predicate)(g, eclass)
-      for (j, n) in enumerate(eclass.nodes)
-        if !v_isexpr(n)
-          $(Symbol(:enode_idx, addr)) = j + 1
-          break
-        end
-      end
+      # for (j, n) in enumerate(eclass.nodes)
+      #   if !v_isexpr(n)
+      #     $(Symbol(:enode_idx, addr)) = j + 1
+      #     break
+      #   end
+      # end
+      $(Symbol(:enode_idx, addr)) = 1
       pc += 0x0001
       @goto compute
     end
@@ -330,7 +331,7 @@ function yield_expr(patvar_to_addr, direction)
       id = $(Symbol(:σ, addr))
       eclass = g[id]
       node_idx = $(Symbol(:enode_idx, addr)) - 1
-      if node_idx == 0
+      if node_idx <= 0
         push!(ematch_buffer, v_pair(id, reinterpret(UInt64, 0)))
       else
         n = eclass.nodes[node_idx]

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -49,6 +49,7 @@ function ematch_compile(p, pvars, direction)
       root_id::$(Metatheory.Id),
       stack::$(Metatheory.OptBuffer){UInt16},
       ematch_buffer::$(Metatheory.OptBuffer){UInt128},
+      limit::$(Int)=$(typemax(Int))
     )::Int
       # If the constants in the pattern are not all present in the e-graph, just return 
       $(pat_constants_checks...)
@@ -70,7 +71,7 @@ function ematch_compile(p, pvars, direction)
       # 2) When an instruction succeeds, the pc is incremented.  
       @label compute
       # Instruction 0 is used to return when  the backtracking stack is empty. 
-      pc === 0x0000 && return n_matches
+      (pc === 0x0000 || n_matches >= limit) && return n_matches
 
       # For each instruction in the program, create an if statement, 
       # Checking if the current value 

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -259,7 +259,7 @@ function check_var_expr(addr, predicate::Function)
       #     break
       #   end
       # end
-      $(Symbol(:enode_idx, addr)) = 1
+      # $(Symbol(:enode_idx, addr)) = 1
       pc += 0x0001
       @goto compute
     end

--- a/src/optbuffer.jl
+++ b/src/optbuffer.jl
@@ -30,7 +30,11 @@ Base.@inline function Base.pop!(b::OptBuffer{T})::T where {T}
   val
 end
 
-Base.resize!(b::OptBuffer{T}, n::Int) where {T} = b.i = n
+function Base.resize!(b::OptBuffer{T}, n::Int) where {T}
+  @assert n >= 0
+  @assert n <= b.i "Increasing the length of OptBuffer is not supported"
+  b.i = n
+end
 Base.isempty(b::OptBuffer{T}) where {T} = b.i === 0
 Base.empty!(b::OptBuffer{T}) where {T} = (b.i = 0)
 @inline Base.length(b::OptBuffer{T}) where {T} = b.i

--- a/src/optbuffer.jl
+++ b/src/optbuffer.jl
@@ -30,7 +30,7 @@ Base.@inline function Base.pop!(b::OptBuffer{T})::T where {T}
   val
 end
 
-
+Base.resize!(b::OptBuffer{T}, n::Int) where {T} = b.i = n
 Base.isempty(b::OptBuffer{T}) where {T} = b.i === 0
 Base.empty!(b::OptBuffer{T}) where {T} = (b.i = 0)
 @inline Base.length(b::OptBuffer{T}) where {T} = b.i


### PR DESCRIPTION
For valid performance comparisons, with egg we should produce egraphs that have comparable sizes to the egraphs produced by egg. Currently, this is not the case because MT has a bug when using BackoffScheduler (informed with incorrect number of matches). Additionally, the implementation of BackoffScheduler is different to egg, leading to different egraph sizes (for the same rules, and saturation timeout). 

egg allows to limit the number of matches in the ematcher to the threshold calculated from the BackoffScheduler which has additional performance advantages.

Fixes #248.