### PR TITLE
Performance improvements

### DIFF
--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -1,4 +1,4 @@
-# Sketch function for basic iterative saturation and extraction 
+# Sketch function for basic iterative saturation and extraction
 function prove(
   t,
   ex,

--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -32,9 +32,9 @@ function test_equality(t, exprs...; params = SaturationParams(), g = EGraph())
   params = deepcopy(params)
   params.goal = (g::EGraph) -> in_same_class(g, ids...)
 
+  g.root = first(ids) # to allow extraction (for debugging)
   report = saturate!(g, t, params)
   goal_reached = params.goal(g)
-
   if !(report.reason === :saturated) && !goal_reached
     return false # failed to prove
   end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -281,7 +281,7 @@ function add!(g::EGraph{ExpressionType,Analysis}, n::VecExpr, should_copy::Bool)
   g.classes[IdKey(id)] = eclass
   modify!(g, eclass)
 
-  # push!(g.pending, id) #  We just created a new eclass for a new node. No need to reprocess parents (TODO: check)
+  # push!(g.pending, id) #  We just created a new eclass for a new node. No need to reprocess parents
 
   return id
 end
@@ -352,8 +352,8 @@ function Base.union!(
   eclass_2 = pop!(g.classes, id_2)::EClass
   eclass_1 = g.classes[id_1]::EClass
 
-  push!(g.pending, merged_id) 
-  # push!(g.pending, id_2.val) # TODO: sufficient?
+  # push!(g.pending, merged_id) 
+  push!(g.pending, id_2.val) # TODO: it seems sufficient, to queue parents of id_2.val?
 
   (merged_1, merged_2, new_data) = merge_analysis_data!(eclass_1, eclass_2)
   merged_1 && push!(g.analysis_pending, id_1.val)
@@ -483,7 +483,7 @@ function repair_parents!(g::EGraph, id::Id)
     for i in Iterators.drop(eachindex(eclass.parents), 1)
       (cur_node, cur_id) = eclass.parents[i]
       
-      if cur_node == prev_node  # could check hash(cur_node) == hash(prev_node) first
+      if hash(cur_node) == hash(prev_node) && cur_node == prev_node
         if union!(g, cur_id, prev_id) 
           n_unions += 1
         end
@@ -495,7 +495,7 @@ function repair_parents!(g::EGraph, id::Id)
     end
     
     # TODO: remove assertions
-    @assert length(unique(pair -> pair[1], new_parents)) == length(new_parents)  "not unique: $new_parents"
+    # @assert length(unique(pair -> pair[1], new_parents)) == length(new_parents)  "not unique: $new_parents"
     # @assert all(pair -> pair[2] == find(g, pair[2]), new_parents)  "not refering to eclasses: $(new_parents)\n $g"
     
     eclass.parents = new_parents

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -245,7 +245,11 @@ end
 
 function add_class_by_op(g::EGraph, n, eclass_id)
   key = IdKey(v_signature(n))
-  vec = get!(g.classes_by_op, key, Vector{Id}())
+  vec = get(g.classes_by_op, key, nothing)
+  if isnothing(vec)
+    vec = Id[eclass_id]
+    g.classes_by_op[key] = vec
+  end
   push!(vec, eclass_id)
 end
 

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -209,7 +209,7 @@ export pretty_dict
 function Base.show(io::IO, g::EGraph)
   d = pretty_dict(g)
   t = "$(typeof(g)) with $(length(d)) e-classes:"
-  cs = map(sort!(collect(d); by = first)) do (k, (nodes, parents))
+  cs = map(sort!(collect(d); by = first)) do (k, nodes)
     "  $k => [$(Base.join(nodes, ", "))]"
   end
   print(io, Base.join([t; cs], "\n"))

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -389,11 +389,11 @@ function rebuild_classes!(g::EGraph)
 
   trimmed_nodes = 0
   for (eclass_id, eclass) in g.classes
-    for n in eclass.nodes
-      memo_class = pop!(g.memo, n, 0)
-      canonicalize!(g, n)
-      g.memo[n] = eclass_id.val
-    end
+    # for n in eclass.nodes
+    #   memo_class = pop!(g.memo, n, 0)
+    #   canonicalize!(g, n)
+    #   g.memo[n] = eclass_id.val
+    # end
     # TODO Sort to go in order?
     trimmed_nodes += length(eclass.nodes)
     unique!(eclass.nodes)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -503,7 +503,7 @@ function repair_parents!(g::EGraph, id::Id)
   n_unions
 end
 function update_analysis_upwards!(g::EGraph, id::Id)
-  for (p_node, p_id) in g.classes[IdKey(id)]
+  for (p_node, p_id) in g[id].parents
     p_id = find(g, p_id)
     eclass = g.classes[IdKey(p_id)]
 
@@ -515,12 +515,12 @@ function update_analysis_upwards!(g::EGraph, id::Id)
         if joined_data != eclass.data
           eclass.data = joined_data
           modify!(g, eclass)
-          append!(g.analysis_pending, eclass.parents)
+          append!(g.analysis_pending, p_id)
         end
       else
         eclass.data = node_data
         modify!(g, eclass)
-        append!(g.analysis_pending, eclass.parents)
+        append!(g.analysis_pending, p_id)
       end
     end
   end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -198,9 +198,9 @@ function to_expr(g::EGraph, n::VecExpr)
 end
 
 function pretty_dict(g::EGraph)
-  d = Dict{Int,Tuple{Vector{Any},Vector{Any}}}()
+  d = Dict{Int,Vector{Any}}()
   for (class_id, eclass) in g.classes
-    d[class_id.val] = (map(n -> to_expr(g, n), eclass.nodes), map(pair -> (Int(pair[2]), Int(find(g, pair[2]))), eclass.parents))
+    d[class_id.val] = (map(n -> to_expr(g, n), eclass.nodes))
   end
   d
 end
@@ -210,7 +210,7 @@ function Base.show(io::IO, g::EGraph)
   d = pretty_dict(g)
   t = "$(typeof(g)) with $(length(d)) e-classes:"
   cs = map(sort!(collect(d); by = first)) do (k, (nodes, parents))
-    "  $k => [$(Base.join(nodes, ", "))], parents: [$(Base.join(parents, ", "))]"
+    "  $k => [$(Base.join(nodes, ", "))]"
   end
   print(io, Base.join([t; cs], "\n"))
 end

--- a/src/EGraphs/extract.jl
+++ b/src/EGraphs/extract.jl
@@ -85,9 +85,9 @@ function find_costs!(extractor::Extractor{CF,CT}) where {CF,CT}
   end
 
   for (id, _) in extractor.g.classes
-    if !haskey(extractor.costs, id)
-      error("failed to compute extraction costs for eclass ", id.val)
-    end
+    # if !haskey(extractor.costs, id)
+    #   error("failed to compute extraction costs for eclass ", id.val)
+    # end
   end
 end
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -109,7 +109,7 @@ function eqsat_search!(
       # if n_matches - prev_matches > 2 && rule_idx == 2
       #   @debug buffer_readable(g, old_len)
       # end
-      inform!(scheduler, rule_idx, n_matches)
+      inform!(scheduler, rule_idx, n_matches - prev_matches)
     end
   end
 
@@ -214,7 +214,7 @@ function eqsat_apply!(
     if n_matches % CHECK_GOAL_EVERY_N_MATCHES == 0 && params.goal(g)
       @debug "Goal reached"
       rep.reason = :goalreached
-      return
+      break
     end
 
     delimiter = ematch_buffer.v[k]

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -146,14 +146,12 @@ end
 Instantiate argument for dynamic rule application in e-graph
 """
 function instantiate_actual_param!(bindings, g::EGraph, i)
+  const_hash = v_pair_last(bindings[i])
+  const_hash == 0 || return get_constant(g, const_hash)
+
   ecid = v_pair_first(bindings[i])
-  literal_position = reinterpret(Int, v_pair_last(bindings[i]))
   ecid <= 0 && error("unbound pattern variable")
   eclass = g[ecid]
-  if literal_position > 0
-    @assert !v_isexpr(eclass[literal_position])
-    return get_constant(g, v_head(eclass[literal_position]))
-  end
   return eclass
 end
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -109,7 +109,7 @@ function eqsat_search!(
       # if n_matches - prev_matches > 2 && rule_idx == 2
       #   @debug buffer_readable(g, old_len)
       # end
-      inform!(scheduler, rule_idx, n_matches - prev_matches)
+      inform!(scheduler, rule_idx, n_matches) # TODO - prev_matches
     end
   end
 
@@ -327,7 +327,7 @@ function saturate!(g::EGraph, theory::Theory, params = SaturationParams())
     curr_iter += 1
 
     @debug "================ EQSAT ITERATION $curr_iter  ================"
-    @debug g
+    # @debug g
 
     report = eqsat_step!(g, theory, curr_iter, sched, params, report, ematch_buffer)
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -40,6 +40,8 @@ Base.@kwdef mutable struct SaturationParams
   check_memo::Bool = false
   "Activate check for join-semilattice invariant for semantic analysis values after rebuilding"
   check_analysis::Bool = false
+  "Activate check for parent vectors"
+  check_parents::Bool = false
 end
 
 function cached_ids(g::EGraph, p::PatExpr)::Vector{Id}

--- a/src/EGraphs/unionfind.jl
+++ b/src/EGraphs/unionfind.jl
@@ -18,8 +18,10 @@ function Base.union!(uf::UnionFind, i::Id, j::Id)
 end
 
 function find(uf::UnionFind, i::Id)
+  # path splitting
   while i != uf.parents[i]
-    i = uf.parents[i]
+    (i, uf.parents[i]) = (uf.parents[i], uf.parents[uf.parents[i]])
   end
+
   i
 end

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -96,11 +96,11 @@ end
 check_constant_exprs!(buf, p::PatLiteral) = push!(buf, :(has_constant(g, $(last(p.n))) || return 0))
 check_constant_exprs!(buf, ::AbstractPat) = buf
 function check_constant_exprs!(buf, p::PatExpr)
-  if !(p.head isa AbstractPat)
-    push!(buf, :(has_constant(g, $(p.head_hash)) || has_constant(g, $(p.quoted_head_hash)) || return 0))
-  end
   for child in children(p)
     check_constant_exprs!(buf, child)
+  end
+  if !(p.head isa AbstractPat)
+    push!(buf, :(has_constant(g, $(p.head_hash)) || has_constant(g, $(p.quoted_head_hash)) || return 0))
   end
   buf
 end

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -249,12 +249,12 @@ function check_var_expr(addr, predicate::Function)
   quote
     eclass = g[$(Symbol(:σ, addr))]
     if ($predicate)(g, eclass)
-      for (j, n) in enumerate(eclass.nodes)
-        if !v_isexpr(n)
-          $(Symbol(:enode_idx, addr)) = j + 1
-          break
-        end
-      end
+      # for (j, n) in enumerate(eclass.nodes)
+      #   if !v_isexpr(n)
+      #     $(Symbol(:enode_idx, addr)) = j + 1
+      #     break
+      #   end
+      # end
       pc += 0x0001
       @goto compute
     end
@@ -322,7 +322,17 @@ end
 
 function yield_expr(patvar_to_addr, direction)
   push_exprs = [
-    :(push!(ematch_buffer, v_pair($(Symbol(:σ, addr)), reinterpret(UInt64, $(Symbol(:enode_idx, addr)) - 1)))) for
+    quote
+      id = $(Symbol(:σ, addr))
+      eclass = g[id]
+      node_idx = $(Symbol(:enode_idx, addr)) - 1
+      if node_idx <= 0
+        push!(ematch_buffer, v_pair(id, reinterpret(UInt64, 0)))
+      else
+        n = eclass.nodes[node_idx]
+        push!(ematch_buffer, v_pair(id, v_head(n)))
+      end
+    end for
     addr in patvar_to_addr
   ]
   quote

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -209,8 +209,8 @@ function bind_expr(addr, p::PatExpr, memrange)
       n = eclass.nodes[$(Symbol(:enode_idx, addr))]
 
       v_flags(n) === $(v_flags(p.n)) || @goto $(Symbol(:skip_node, addr))
-      v_signature(n) === $(v_signature(p.n)) || @goto $(Symbol(:skip_node, addr))
-      v_head(n) === $(v_head(p.n)) || (v_head(n) === $(p.quoted_head_hash) || @goto $(Symbol(:skip_node, addr)))
+      v_signature(n) === $(v_signature(p.n)) || @goto $(Symbol(:skip_node, addr)) # TODO better to check signature before flags? check perf.
+      v_head(n) === $(v_head(p.n)) || v_head(n) === $(p.quoted_head_hash) || @goto $(Symbol(:skip_node, addr))
 
       # Node has matched.
       $([:($(Symbol(:σ, j)) = n[$i + $VECEXPR_META_LENGTH]) for (i, j) in enumerate(memrange)]...)

--- a/src/optbuffer.jl
+++ b/src/optbuffer.jl
@@ -34,4 +34,4 @@ end
 Base.isempty(b::OptBuffer{T}) where {T} = b.i === 0
 Base.empty!(b::OptBuffer{T}) where {T} = (b.i = 0)
 @inline Base.length(b::OptBuffer{T}) where {T} = b.i
-Base.iterate(b::OptBuffer{T}, i=1) where {T} = iterate(b.v[1:b.i], i)
+Base.iterate(b::OptBuffer{T}, i=1) where {T} = i <= b.i ? (b.v[i], i + 1) : nothing

--- a/src/vecexpr.jl
+++ b/src/vecexpr.jl
@@ -121,4 +121,6 @@ v_pair_last(p::UInt128)::UInt64 = UInt64(p & 0xffffffffffffffff)
 @inline Base.lastindex(n::VecExpr) = lastindex(n.data)
 @inline Base.firstindex(n::VecExpr) = firstindex(n.data)
 
+Base.isless(a::VecExpr,b::VecExpr) = isless(a.data,b.data)
+
 end

--- a/test/egraphs/egraphs.jl
+++ b/test/egraphs/egraphs.jl
@@ -4,10 +4,25 @@ using Test, Metatheory
 @testset "Merging" begin
   testexpr = :((a * 2) / 2)
   testmatch = :(a << 1)
-  g = EGraph(testexpr)
+  g = EGraph()
+  testexpr_id = addexpr!(g, testexpr)
+  t1 = addexpr!(g, :(a * 2)) # get eclass id of a * 2
   t2 = addexpr!(g, testmatch)
-  union!(g, t2, Id(3))
-  @test find(g, t2) == find(g, Id(3))
+  union!(g, t2, t1)
+
+  @testset "Behaviour" begin
+    @test find(g, t2) == find(g, t1)
+  end
+
+  @testset "Internals" begin
+    @test length(g[t1].nodes) == 2 # a << 1, a * 2
+    @test g[t1].parents == [testexpr_id]
+
+    id_1 = addexpr!(g, 1) # get id of constant 1
+    @test g[id_1].parents == [find(g, t1)] # just eclass [a << 1, a * 2]
+    id_a = addexpr!(g, :a)
+    @test g[id_a].parents == [find(g, t1)] # just eclass [a << 1, a * 2]
+  end
 end
 
 # testexpr = :(42a + b * (foo($(Dict(:x => 2)), 42)))
@@ -25,10 +40,20 @@ end
   t2 = addexpr!(g, :c)
 
   union!(g, t2, t1)
-  @test find(g, t2) == find(g, t1)
-  @test find(g, t2) == find(g, t1)
-  rebuild!(g)
-  @test find(g, ec1) == find(g, ec2)
+  @testset "Behaviour" begin
+    @test find(g, t2) == find(g, t1)
+    rebuild!(g)
+    @test find(g, ec1) == find(g, ec2)
+    @test length(g[ec2].nodes) == 1
+  end
+
+  @testset "Internals" begin
+    aid = addexpr!(g, :a) # get id of :a
+    @test g[aid].parents == [find(g, ec1)]
+    @test g[t1].parents == [find(g, ec1)]
+    @test g[ec1].parents == [find(g, testec)]
+    @test length(g[testec].nodes) == 1
+  end
 end
 
 
@@ -53,19 +78,26 @@ end
   t3 = addexpr!(g, apply(3, f, :a))
   t4 = addexpr!(g, apply(7, f, :a))
 
-  # f^m(a) = a = f^n(a) ⟹ f^(gcd(m,n))(a) = a
-  @test find(g, t1) == find(g, a)
-  @test find(g, t2) == find(g, a)
-  @test find(g, t3) == find(g, a)
-  @test find(g, t4) != find(g, a)
+  @testset "Behaviour" begin
+    # f^m(a) = a = f^n(a) ⟹ f^(gcd(m,n))(a) = a
+    @test find(g, t1) == find(g, a)
+    @test find(g, t2) == find(g, a)
+    @test find(g, t3) == find(g, a)
+    @test find(g, t4) != find(g, a)
 
-  # if m or n is prime, f(a) = a
-  t5 = addexpr!(g, apply(11, f, :a))
-  t6 = addexpr!(g, apply(1, f, :a))
-  c5_id = union!(g, t5, a) # a == apply(11,f,a)
+    # if m or n is prime, f(a) = a
+    t5 = addexpr!(g, apply(11, f, :a))
+    t6 = addexpr!(g, apply(1, f, :a))
+    c5_id = union!(g, t5, a) # a == apply(11,f,a)
 
-  rebuild!(g)
+    rebuild!(g)
 
-  @test find(g, t5) == find(g, a)
-  @test find(g, t6) == find(g, a)
+    @test find(g, t5) == find(g, a)
+    @test find(g, t6) == find(g, a)
+  end
+
+  @testset "Internals" begin
+    @test length(g.classes) == 1 # only a single class %id [:a, f(%id)] remains
+    @test g[a].parents = [find(g, a)] # there can be only a single parent
+  end
 end

--- a/test/integration/cas.jl
+++ b/test/integration/cas.jl
@@ -1,4 +1,4 @@
-using Metatheory, TermInterface, Test
+using Metatheory, Test
 using Metatheory.Library
 using Metatheory.Schedulers
 
@@ -188,11 +188,11 @@ end
 @test :(y + sec(x)^2) == simplify(:(1 + y + tan(x)^2))
 @test :(y + csc(x)^2) == simplify(:(1 + y + cot(x)^2))
 
-@test_broken simplify(:(diff(x^2, x))) == :(2x)
+@test simplify(:(diff(x^2, x))) == :(2x)
 @test_broken simplify(:(diff(x^(cos(x)), x))) == :((cos(x) / x + -(sin(x)) * log(x)) * x^cos(x))
 @test simplify(:(x * diff(x^2, x) * x)) == :(2x^3)
 
-@test_broken simplify(:(diff(y^3, y) * diff(x^2 + 2, x) / y * x)) == :(6 * y * x ^ 2) # :(3y * 2x^2)
+@test simplify(:(diff(y^3, y) * diff(x^2 + 2, x) / y * x)) == :(6 * y * x ^ 2) # :(3y * 2x^2)
 
 @test simplify(:(6 * x * x * y)) == :(6 * y * x^2)
 @test simplify(:(diff(y^3, y) / y)) == :(3y)

--- a/test/integration/cas.jl
+++ b/test/integration/cas.jl
@@ -145,14 +145,14 @@ function simplcost(n::VecExpr, op, costs)
   1 + sum(costs) + (op in (:∂, diff, :diff) ? 200 : 0)
 end
 
-function simplify(ex; steps = 4)
-  params = SaturationParams(
+function simplify(ex; steps = 4, params=SaturationParams())
+  #params = SaturationParams(
   # scheduler = ScoredScheduler,
   # eclasslimit = 5000,
-  # timeout = 7,
+  # timeout = 2,
   # schedulerparams = (match_limit = 1000, ban_length = 5),
   #stopwhen=stopwhen,
-  )
+  #)
   hist = UInt64[]
   push!(hist, hash(ex))
   for i in 1:steps
@@ -188,11 +188,11 @@ end
 @test :(y + sec(x)^2) == simplify(:(1 + y + tan(x)^2))
 @test :(y + csc(x)^2) == simplify(:(1 + y + cot(x)^2))
 
-@test simplify(:(diff(x^2, x))) == :(2x)
+@test_broken simplify(:(diff(x^2, x))) == :(2x)
 @test_broken simplify(:(diff(x^(cos(x)), x))) == :((cos(x) / x + -(sin(x)) * log(x)) * x^cos(x))
 @test simplify(:(x * diff(x^2, x) * x)) == :(2x^3)
 
-@test simplify(:(diff(y^3, y) * diff(x^2 + 2, x) / y * x)) == :(6 * y * x ^ 2) # :(3y * 2x^2)
+@test_broken simplify(:(diff(y^3, y) * diff(x^2 + 2, x) / y * x)) == :(6 * y * x ^ 2) # :(3y * 2x^2)
 
 @test simplify(:(6 * x * x * y)) == :(6 * y * x^2)
 @test simplify(:(diff(y^3, y) / y)) == :(3y)

--- a/test/tutorials/lambda_theory.jl
+++ b/test/tutorials/lambda_theory.jl
@@ -1,4 +1,4 @@
-using Metatheory, Test, TermInterface
+using Metatheory, Test
 
 # # Lambda theory
 #


### PR DESCRIPTION
Follow up to #239.

The MT code deviates from most recent egg code slightly since the changes from https://github.com/egraphs-good/egg/pull/291 which mentiones _"There are also memory usage/performance advantages since EClass.parents, EGraph.pending, and EGraph.analysis_pending, no longer need to store nodes."_


This PR is exploratory. We should split things up in smaller self-contained PRs later.