### PR TITLE
Fix matching of literals in dynamic rules

### DIFF
--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -144,15 +144,11 @@ end
 Instantiate argument for dynamic rule application in e-graph
 """
 function instantiate_actual_param!(bindings, g::EGraph, i)
+  const_hash = v_pair_last(bindings[i])
+  const_hash == 0 || return get_constant(g, const_hash)
   ecid = v_pair_first(bindings[i])
-  literal_position = reinterpret(Int, v_pair_last(bindings[i]))
   ecid <= 0 && error("unbound pattern variable")
-  eclass = g[ecid]
-  if literal_position > 0
-    @assert !v_isexpr(eclass[literal_position])
-    return get_constant(g, v_head(eclass[literal_position]))
-  end
-  return eclass
+  g[ecid]
 end
 
 
@@ -288,7 +284,6 @@ function eqsat_step!(
   @timeit report.to "Search" eqsat_search!(g, theory, scheduler, report, ematch_buffer)
 
   @timeit report.to "Apply" eqsat_apply!(g, theory, report, params, ematch_buffer)
-
   if report.reason === nothing && cansaturate(scheduler) && isempty(g.pending)
     report.reason = :saturated
   end

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -330,7 +330,17 @@ end
 
 function yield_expr(patvar_to_addr, direction::Int)
   push_exprs = [
-    :(push!(ematch_buffer, v_pair($(Symbol(:σ, addr)), reinterpret(UInt64, $(Symbol(:enode_idx, addr)) - 1)))) for
+    quote
+      id = $(Symbol(:σ, addr))
+      eclass = g[id]
+      node_idx = $(Symbol(:enode_idx, addr)) - 1
+      if node_idx <= 0
+        push!(ematch_buffer, v_pair(id, reinterpret(UInt64, 0)))
+      else
+        n = eclass.nodes[node_idx]
+        push!(ematch_buffer, v_pair(id, v_head(n)))
+      end
+    end for
     addr in patvar_to_addr
   ]
   quote

--- a/test/egraphs/ematch.jl
+++ b/test/egraphs/ematch.jl
@@ -164,6 +164,24 @@ end
 end
 
 
+@testset "Matching Literals in Dynamic Rules" begin
+  g = EGraph()
+
+  ec_xy = addexpr!(g, :(x + y))
+  ec_1 = addexpr!(g, 1)
+  union!(g, ec_xy, ec_1)
+  # 1: x
+  # 2: y
+  # 3: %1 + %2, 1
+
+  r2 = @theory a b begin
+    a::Number => :($a + 0)
+    :x + :y => :y
+  end
+  saturate!(g, r2)
+end
+
+
 comm_monoid = @commutative_monoid (*) 1
 
 @testset "Basic Equalities - Commutative Monoid" begin


### PR DESCRIPTION
The literal_position returned by the ematcher may be invalidated by merging of two eclasses in another rule. 
This PR changes the ematcher rules to always return the hash of the enode (even for literals). 