### PR TITLE
Update benchmarks to report the egraph size for each case

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -62,14 +62,14 @@ SUITE["basic_maths"]["simpl1"] = begin
     postprocess_maths,
   ))
   @eval check_result($quoted_expr, :(a + b + d), "basic_maths_simpl1")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 simpl2_math = :(0 + (1 * foo) * 0 + (a * 0) + a)
 SUITE["basic_maths"]["simpl2"] = begin
   quoted_expr = :(simplify(simpl2_math, maths_theory, SaturationParams(), postprocess_maths))
   @eval check_result($quoted_expr, :a, "basic_maths_simpl2")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 # ==================================================================
@@ -84,21 +84,21 @@ SUITE["prop_logic"]["rewrite"] = @benchmarkable rewrite($ex_orig, $impl)
 SUITE["prop_logic"]["prove1"] = begin 
   quoted_expr = :(prove(propositional_logic_theory, ex_logic, 3, 6))
   @eval check_result($quoted_expr, true, "prop_logic_prove1")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 ex_demorgan = :(!(p || q) == (!p && !q))
 SUITE["prop_logic"]["demorgan"] = begin
   quoted_expr = :(prove(propositional_logic_theory, ex_demorgan))
   @eval check_result($quoted_expr, true, "prop_logic_demorgan")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 ex_frege = :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))
 SUITE["prop_logic"]["freges_theorem"] = begin
   quoted_expr = :(prove(propositional_logic_theory, ex_frege))
   @eval check_result($quoted_expr, true, "prop_logic_freges_theorem")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 # ==================================================================
@@ -108,7 +108,7 @@ SUITE["calc_logic"] = BenchmarkGroup(["egraph", "logic"])
 SUITE["calc_logic"]["demorgan"] = begin
   quoted_expr = :(prove(calculational_logic_theory, ex_demorgan))
   @eval check_result($quoted_expr, true, "calc_logic_demorgan")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 # TODO FIXME After https://github.com/JuliaSymbolics/Metatheory.jl/pull/261/ the order of application of
@@ -118,7 +118,7 @@ end
 SUITE["calc_logic"]["freges_theorem"] = begin
   quoted_expr = :(prove((reverse(calculational_logic_theory)), ex_frege, 2, 10))
   @eval check_result($quoted_expr, true, "calc_logic_freges_theorem")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 # ==================================================================
@@ -145,7 +145,7 @@ SUITE["while_superinterpreter"]["while_10"] = begin
   expected = 10
   quoted_expr = :(bench_while_superinterpreter(exx, $expected))
   @eval check_result($quoted_expr, $expected, "while_superinterpreter_while_10")
-  @benchmarkable $quoted_expr
+  @eval @benchmarkable $quoted_expr
 end
 
 SUITE

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -90,7 +90,11 @@ function nested_expr(level)
   end
 end
 
-SUITE["egraph"]["addexpr"] = @benchmarkable EGraph($(nested_expr(2000)))
+SUITE["egraph"]["addexpr"] = begin
+  ex = nested_expr(2000)
+  report_size("egraph/addexpr", EGraphSize(EGraph(ex)))
+  @eval @benchmarkable EGraph($ex)
+end
 
 
 # ==================================================================

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -61,14 +61,14 @@ SUITE["basic_maths"]["simpl1"] = begin
     (SaturationParams(; timer = false)),
     postprocess_maths,
   ))
-  @eval check_result($quoted_expr, :(a + b + d), "basic_maths_simpl1")
+  @eval check_result($quoted_expr, :(a + b + d), "basic_maths/simpl1")
   @eval @benchmarkable $quoted_expr
 end
 
 simpl2_math = :(0 + (1 * foo) * 0 + (a * 0) + a)
 SUITE["basic_maths"]["simpl2"] = begin
   quoted_expr = :(simplify(simpl2_math, maths_theory, SaturationParams(), postprocess_maths))
-  @eval check_result($quoted_expr, :a, "basic_maths_simpl2")
+  @eval check_result($quoted_expr, :a, "basic_maths/simpl2")
   @eval @benchmarkable $quoted_expr
 end
 
@@ -83,21 +83,21 @@ SUITE["prop_logic"]["rewrite"] = @benchmarkable rewrite($ex_orig, $impl)
 
 SUITE["prop_logic"]["prove1"] = begin 
   quoted_expr = :(prove(propositional_logic_theory, ex_logic, 3, 6))
-  @eval check_result($quoted_expr, true, "prop_logic_prove1")
+  @eval check_result($quoted_expr, true, "prop_logic/prove1")
   @eval @benchmarkable $quoted_expr
 end
 
 ex_demorgan = :(!(p || q) == (!p && !q))
 SUITE["prop_logic"]["demorgan"] = begin
   quoted_expr = :(prove(propositional_logic_theory, ex_demorgan))
-  @eval check_result($quoted_expr, true, "prop_logic_demorgan")
+  @eval check_result($quoted_expr, true, "prop_logic/demorgan")
   @eval @benchmarkable $quoted_expr
 end
 
 ex_frege = :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))
 SUITE["prop_logic"]["freges_theorem"] = begin
   quoted_expr = :(prove(propositional_logic_theory, ex_frege))
-  @eval check_result($quoted_expr, true, "prop_logic_freges_theorem")
+  @eval check_result($quoted_expr, true, "prop_logic/freges_theorem")
   @eval @benchmarkable $quoted_expr
 end
 
@@ -107,7 +107,7 @@ SUITE["calc_logic"] = BenchmarkGroup(["egraph", "logic"])
 
 SUITE["calc_logic"]["demorgan"] = begin
   quoted_expr = :(prove(calculational_logic_theory, ex_demorgan))
-  @eval check_result($quoted_expr, true, "calc_logic_demorgan")
+  @eval check_result($quoted_expr, true, "calc_logic/demorgan")
   @eval @benchmarkable $quoted_expr
 end
 
@@ -117,7 +117,7 @@ end
 # See comments in https://github.com/JuliaSymbolics/Metatheory.jl/pull/261#pullrequestreview-2609050078
 SUITE["calc_logic"]["freges_theorem"] = begin
   quoted_expr = :(prove((reverse(calculational_logic_theory)), ex_frege, 2, 10))
-  @eval check_result($quoted_expr, true, "calc_logic_freges_theorem")
+  @eval check_result($quoted_expr, true, "calc_logic/freges_theorem")
   @eval @benchmarkable $quoted_expr
 end
 
@@ -144,7 +144,7 @@ end
 SUITE["while_superinterpreter"]["while_10"] = begin
   expected = 10
   quoted_expr = :(bench_while_superinterpreter(exx, $expected))
-  @eval check_result($quoted_expr, $expected, "while_superinterpreter_while_10")
+  @eval check_result($quoted_expr, $expected, "while_superinterpreter/while_10")
   @eval @benchmarkable $quoted_expr
 end
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -93,7 +93,7 @@ end
 SUITE["egraph"]["addexpr"] = begin
   ex = nested_expr(2000)
   report_size("egraph/addexpr", EGraphSize(EGraph(ex)))
-  @eval @benchmarkable EGraph($ex)
+  @benchmarkable EGraph(ex)
 end
 
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -8,7 +8,7 @@ function simplify(ex, theory, params = SaturationParams(), postprocess = identit
   g = EGraph(ex)
   saturate!(g, theory, params)
   res = extract!(g, astsize)
-  postprocess(res)
+  postprocess(res), g
 end
 
 
@@ -40,17 +40,26 @@ SUITE["basic_maths"] = BenchmarkGroup(["egraphs"])
 
 
 simpl1_math = :(a + b + (0 * c) + d)
-SUITE["basic_maths"]["simpl1"] = @benchmarkable (@assert :(a + b + d) == simplify(
-  $simpl1_math,
-  $maths_theory,
-  $(SaturationParams(; timer = false)),
-  postprocess_maths,
-))
+SUITE["basic_maths"]["simpl1"] = begin
+  expr, g = simplify(
+    simpl1_math,
+    maths_theory,
+    SaturationParams(; timer = false),
+    postprocess_maths,
+  )
+  report_size("basic_maths_simpl1", g)
+  @assert :(a + b + d) == expr
+
+  @benchmarkable simplify($simpl1_math, $maths_theory, $(SaturationParams(; timer = false)), postprocess_maths)
+end
 
 simpl2_math = :(0 + (1 * foo) * 0 + (a * 0) + a)
-SUITE["basic_maths"]["simpl2"] =
-  @benchmarkable (@assert :a == simplify($simpl2_math, $maths_theory, $(SaturationParams()), postprocess_maths))
-
+SUITE["basic_maths"]["simpl2"] = begin
+  expr,g = simplify(simpl2_math, maths_theory, (SaturationParams()), postprocess_maths)
+  report_size("basic_maths_simpl2", g)
+  @assert :a == expr
+  @benchmarkable simplify($simpl2_math, $maths_theory, $(SaturationParams()), postprocess_maths)
+end
 
 # ==================================================================
 
@@ -60,25 +69,51 @@ ex_orig = :(((p ⟹ q) && (r ⟹ s) && (p || r)) ⟹ (q || s))
 ex_logic = rewrite(ex_orig, impl)
 
 SUITE["prop_logic"]["rewrite"] = @benchmarkable rewrite($ex_orig, $impl)
-SUITE["prop_logic"]["prove1"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_logic, 3, 6))
+
+SUITE["prop_logic"]["prove1"] = begin 
+  expr,g = prove(propositional_logic_theory, ex_logic, 3, 6)
+  report_size("prop_logic_prove1", g)
+  @assert expr == true
+  @benchmarkable prove($propositional_logic_theory, $ex_logic, 3, 6)
+end
 
 ex_demorgan = :(!(p || q) == (!p && !q))
-SUITE["prop_logic"]["demorgan"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_demorgan))
+SUITE["prop_logic"]["demorgan"] = begin
+  expr,g = prove(propositional_logic_theory, ex_demorgan)
+  report_size("prop_logic_demorgan", g)
+  @assert expr == true
+  @benchmarkable prove($propositional_logic_theory, $ex_demorgan)
+end
 
 ex_frege = :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))
-SUITE["prop_logic"]["freges_theorem"] = @benchmarkable (@assert prove($propositional_logic_theory, $ex_frege))
+SUITE["prop_logic"]["freges_theorem"] = begin
+  expr,g = prove(propositional_logic_theory, ex_frege)
+  report_size("prop_logic_freges_theorem", g)
+  @assert expr == true
+  @benchmarkable prove($propositional_logic_theory, $ex_frege)
+end
 
 # ==================================================================
 
 SUITE["calc_logic"] = BenchmarkGroup(["egraph", "logic"])
 
-SUITE["calc_logic"]["demorgan"] = @benchmarkable (@assert prove($calculational_logic_theory, $ex_demorgan))
+SUITE["calc_logic"]["demorgan"] = begin
+  expr,g = prove(calculational_logic_theory, ex_demorgan)
+  report_size("calc_logic_demorgan", g)
+  @assert expr == true
+  @benchmarkable prove($calculational_logic_theory, $ex_demorgan)
+end
+
 # TODO FIXME After https://github.com/JuliaSymbolics/Metatheory.jl/pull/261/ the order of application of
 # matches in ematch_buffer has been reversed. There is likely some issue in rebuilding such that the
 # order of application of rules changes the resulting e-graph, while this should not be the case.
 # See comments in https://github.com/JuliaSymbolics/Metatheory.jl/pull/261#pullrequestreview-2609050078
-SUITE["calc_logic"]["freges_theorem"] =
-  @benchmarkable (@assert prove($(reverse(calculational_logic_theory)), $ex_frege, 2, 10))
+SUITE["calc_logic"]["freges_theorem"] = begin
+  expr,g = prove((reverse(calculational_logic_theory)), ex_frege, 2, 10)
+  report_size("calc_logic_freges_theorem", g)
+  @assert expr == true
+  @benchmarkable prove($(reverse(calculational_logic_theory)), $ex_frege, 2, 10)
+end
 
 # ==================================================================
 
@@ -96,8 +131,23 @@ function bench_while_superinterpreter(expr, expected)
   id2 = addexpr!(g, expected)
   goal = (g::EGraph) -> in_same_class(g, id1, id2)
   params = SaturationParams(timeout = 100, goal = goal, scheduler = Schedulers.SimpleScheduler)
-  rep = saturate!(g, while_language, params)
-  @assert expected == extract!(g, astsize)
+  saturate!(g, while_language, params)
+  extract!(g, astsize), g
 end
 
-SUITE["while_superinterpreter"]["while_10"] = @benchmarkable bench_while_superinterpreter($exx, 10)
+SUITE["while_superinterpreter"]["while_10"] = begin
+  expected = 10
+  expr,g = bench_while_superinterpreter(exx, expected)
+  report_size("while_superinterpreter_while_10", g)
+  @assert expr == expected
+  @benchmarkable bench_while_superinterpreter($exx, $expected)
+end
+
+function report_size(bench, g)
+  n_classes = length(g.classes)
+  n_nodes = sum(length(c.nodes) for c in values(g.classes))
+  n_memo = length(g.memo)
+  println("$bench n_classes: $n_classes, n_nodes: $n_nodes, n_memo: $n_memo")
+end
+
+SUITE

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -12,6 +12,14 @@ function simplify(ex, theory, params = SaturationParams(), postprocess = identit
 end
 
 
+function report_size(bench, g)
+  n_classes = length(g.classes)
+  n_nodes = sum(length(c.nodes) for c in values(g.classes))
+  n_memo = length(g.memo)
+  println("$bench n_classes: $n_classes, n_nodes: $n_nodes, n_memo: $n_memo")
+end
+
+
 include(joinpath(dirname(pathof(Metatheory)), "../examples/prove.jl"))
 include(joinpath(dirname(pathof(Metatheory)), "../examples/basic_maths_theory.jl"))
 include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_theory.jl"))
@@ -141,13 +149,6 @@ SUITE["while_superinterpreter"]["while_10"] = begin
   report_size("while_superinterpreter_while_10", g)
   @assert expr == expected
   @benchmarkable bench_while_superinterpreter($exx, $expected)
-end
-
-function report_size(bench, g)
-  n_classes = length(g.classes)
-  n_nodes = sum(length(c.nodes) for c in values(g.classes))
-  n_memo = length(g.memo)
-  println("$bench n_classes: $n_classes, n_nodes: $n_nodes, n_memo: $n_memo")
 end
 
 SUITE

--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -20,10 +20,10 @@ function prove(
     saturate!(g, t, params)
     ex = extract!(g, astsize)
     if !TermInterface.isexpr(ex)
-      return ex
+      return ex, g
     end
   end
-  return ex
+  return ex, g
 end
 
 function test_equality(t, exprs...; params = SaturationParams(), g = EGraph())

--- a/examples/prove.jl
+++ b/examples/prove.jl
@@ -1,29 +1,24 @@
 # Sketch function for basic iterative saturation and extraction 
-function prove(
-  t,
-  ex,
-  steps = 1,
-  timeout = 10,
-  params = SaturationParams(
-    timeout = timeout,
-    scheduler = Schedulers.BackoffScheduler,
-    schedulerparams = (match_limit = 6000, ban_length = 5),
-    timer = false,
-  ),
-)
+function prove(t, ex, steps = 1, timeout = 10, params = SaturationParams(
+  timeout = timeout,
+  scheduler = Schedulers.BackoffScheduler,
+  schedulerparams = (match_limit = 6000, ban_length = 5),
+  timer = false,
+))
   for _ in 1:steps
     g = EGraph(ex)
-
+  
     ids = [addexpr!(g, true), g.root]
-
+  
     params.goal = (g::EGraph) -> in_same_class(g, ids...)
     saturate!(g, t, params)
     ex = extract!(g, astsize)
+
     if !TermInterface.isexpr(ex)
-      return ex, g
+      return ex
     end
   end
-  return ex, g
+  ex
 end
 
 function test_equality(t, exprs...; params = SaturationParams(), g = EGraph())
@@ -38,5 +33,5 @@ function test_equality(t, exprs...; params = SaturationParams(), g = EGraph())
   if !(report.reason === :saturated) && !goal_reached
     return false # failed to prove
   end
-  return goal_reached
+  goal_reached
 end

--- a/test/tutorials/calculational_logic.jl
+++ b/test/tutorials/calculational_logic.jl
@@ -13,12 +13,12 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_t
   @test test_equality(calculational_logic_theory, :((!p || !p) == !p), :(!p || p), :(!(!p && p)))
 
 
-  @test prove(calculational_logic_theory, :((!p == p) == false))
-  @test prove(calculational_logic_theory, :((!p == !p) == true))
-  @test prove(calculational_logic_theory, :((p ⟹ (p || p)) == true))
+  @test true == prove(calculational_logic_theory, :((!p == p) == false))[1]
+  @test true == prove(calculational_logic_theory, :((!p == !p) == true))[1]
+  @test true == prove(calculational_logic_theory, :((p ⟹ (p || p)) == true))[1]
 
   params = SaturationParams(timeout = 12, eclasslimit = 10000, schedulerparams = (match_limit = 1000, ban_length = 5))
-  @test prove(calculational_logic_theory, :(((p ⟹ (p || p)) == ((!(p) && q) ⟹ q))), 1, 10, params)
+  @test true == prove(calculational_logic_theory, :(((p ⟹ (p || p)) == ((!(p) && q) ⟹ q))), 1, 10, params)[1]
 
   freges = :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))   # Frege's theorem
   params = SaturationParams(timeout = 12, eclasslimit = 10000, schedulerparams = (match_limit = 6000, ban_length = 5))
@@ -26,7 +26,7 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_t
   # matches in ematch_buffer has been reversed. There is likely some issue in rebuilding such that the
   # order of application of rules changes the resulting e-graph, while this should not be the case.
   # See comments in https://github.com/JuliaSymbolics/Metatheory.jl/pull/261#pullrequestreview-2609050078
-  @test prove(reverse(calculational_logic_theory), freges, 2, 10, params)
+  @test true == prove(reverse(calculational_logic_theory), freges, 2, 10, params)[1]
 
-  @test true == prove(calculational_logic_theory, :(!(p || q) == (!p && !q)))   # Demorgan's
+  @test true == prove(calculational_logic_theory, :(!(p || q) == (!p && !q)))[1]   # Demorgan's
 end

--- a/test/tutorials/calculational_logic.jl
+++ b/test/tutorials/calculational_logic.jl
@@ -13,12 +13,12 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_t
   @test test_equality(calculational_logic_theory, :((!p || !p) == !p), :(!p || p), :(!(!p && p)))
 
 
-  @test true == prove(calculational_logic_theory, :((!p == p) == false))[1]
-  @test true == prove(calculational_logic_theory, :((!p == !p) == true))[1]
-  @test true == prove(calculational_logic_theory, :((p ⟹ (p || p)) == true))[1]
+  @test prove(calculational_logic_theory, :((!p == p) == false))
+  @test prove(calculational_logic_theory, :((!p == !p) == true))
+  @test prove(calculational_logic_theory, :((p ⟹ (p || p)) == true))
 
   params = SaturationParams(timeout = 12, eclasslimit = 10000, schedulerparams = (match_limit = 1000, ban_length = 5))
-  @test true == prove(calculational_logic_theory, :(((p ⟹ (p || p)) == ((!(p) && q) ⟹ q))), 1, 10, params)[1]
+  @test prove(calculational_logic_theory, :(((p ⟹ (p || p)) == ((!(p) && q) ⟹ q))), 1, 10, params)
 
   freges = :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))   # Frege's theorem
   params = SaturationParams(timeout = 12, eclasslimit = 10000, schedulerparams = (match_limit = 6000, ban_length = 5))
@@ -26,7 +26,7 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_t
   # matches in ematch_buffer has been reversed. There is likely some issue in rebuilding such that the
   # order of application of rules changes the resulting e-graph, while this should not be the case.
   # See comments in https://github.com/JuliaSymbolics/Metatheory.jl/pull/261#pullrequestreview-2609050078
-  @test true == prove(reverse(calculational_logic_theory), freges, 2, 10, params)[1]
+  @test prove(reverse(calculational_logic_theory), freges, 2, 10, params)
 
-  @test true == prove(calculational_logic_theory, :(!(p || q) == (!p && !q)))[1]   # Demorgan's
+  @test prove(calculational_logic_theory, :(!(p || q) == (!p && !q)))  # Demorgan's
 end

--- a/test/tutorials/propositional_logic.jl
+++ b/test/tutorials/propositional_logic.jl
@@ -7,20 +7,20 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_t
 
 @testset "Prop logic" begin
   ex = rewrite(:(((p ⟹ q) && (r ⟹ s) && (p || r)) ⟹ (q || s)), impl)
-  @test prove(propositional_logic_theory, ex, 5, 10)
+  @test true == prove(propositional_logic_theory, ex, 5, 10)[1]
 
 
-  @test prove(propositional_logic_theory, :((!p == p) == false))
-  @test prove(propositional_logic_theory, :((!p == !p) == true))
+  @test true == prove(propositional_logic_theory, :((!p == p) == false))[1]
+  @test true == prove(propositional_logic_theory, :((!p == !p) == true))[1]
   @test test_equality(propositional_logic_theory, :((!p || !p) == !p), :(!p || p), :(!(!p && p)))
-  @test prove(propositional_logic_theory, :((p || p) == p))
-  @test prove(propositional_logic_theory, :((p ⟹ (p || p))))
-  @test prove(propositional_logic_theory, :((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)))
+  @test true == prove(propositional_logic_theory, :((p || p) == p))[1]
+  @test true == prove(propositional_logic_theory, :((p ⟹ (p || p))))[1]
+  @test true == prove(propositional_logic_theory, :((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)))[1]
 
-  @test prove(propositional_logic_theory, :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))))# Frege's theorem
+  @test true == prove(propositional_logic_theory, :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))))[1] # Frege's theorem
 
-  @test prove(propositional_logic_theory, :(!(p || q) == (!p && !q))) # Demorgan's
+  @test true == prove(propositional_logic_theory, :(!(p || q) == (!p && !q)))[1] # Demorgan's
 end
 
 # Consensus theorem
-@test true == prove(propositional_logic_theory, :(((x && y) || (!x && z) || (y && z)) == ((x && y) || (!x && z))))
+@test true == prove(propositional_logic_theory, :(((x && y) || (!x && z) || (y && z)) == ((x && y) || (!x && z))))[1]

--- a/test/tutorials/propositional_logic.jl
+++ b/test/tutorials/propositional_logic.jl
@@ -7,20 +7,20 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_t
 
 @testset "Prop logic" begin
   ex = rewrite(:(((p ⟹ q) && (r ⟹ s) && (p || r)) ⟹ (q || s)), impl)
-  @test true == prove(propositional_logic_theory, ex, 5, 10)[1]
+  @test prove(propositional_logic_theory, ex, 5, 10)
 
 
-  @test true == prove(propositional_logic_theory, :((!p == p) == false))[1]
-  @test true == prove(propositional_logic_theory, :((!p == !p) == true))[1]
+  @test prove(propositional_logic_theory, :((!p == p) == false))
+  @test prove(propositional_logic_theory, :((!p == !p) == true))
   @test test_equality(propositional_logic_theory, :((!p || !p) == !p), :(!p || p), :(!(!p && p)))
-  @test true == prove(propositional_logic_theory, :((p || p) == p))[1]
-  @test true == prove(propositional_logic_theory, :((p ⟹ (p || p))))[1]
-  @test true == prove(propositional_logic_theory, :((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)))[1]
+  @test prove(propositional_logic_theory, :((p || p) == p))
+  @test prove(propositional_logic_theory, :((p ⟹ (p || p))))
+  @test prove(propositional_logic_theory, :((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)))
 
-  @test true == prove(propositional_logic_theory, :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))))[1] # Frege's theorem
+  @test prove(propositional_logic_theory, :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r)))) # Frege's theorem
 
-  @test true == prove(propositional_logic_theory, :(!(p || q) == (!p && !q)))[1] # Demorgan's
+  @test prove(propositional_logic_theory, :(!(p || q) == (!p && !q))) # Demorgan's
 end
 
 # Consensus theorem
-@test true == prove(propositional_logic_theory, :(((x && y) || (!x && z) || (y && z)) == ((x && y) || (!x && z))))[1]
+@test prove(propositional_logic_theory, :(((x && y) || (!x && z) || (y && z)) == ((x && y) || (!x && z))))


### PR DESCRIPTION
...  and check he return value assertion only once.

This is useful to compare the behaviour of MT to egg additionally to the runtime.
