### PR TITLE
Document Metatheory public interfaces

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Run egg benchmarks
         run: |
+          mkdir -p target
           cd ./egg-benchmark
-          cargo bench
+          cargo bench 2>&1 | tee ../target/egg-log.txt
           # cargo bench -- "basic_maths/simpl1"
           cd ../
 
@@ -46,11 +47,13 @@ jobs:
           echo $PATH
           ls -l ~/.julia/bin
           mkdir results
+          mkdir -p target/mt_results
           benchpkg Metatheory \
             --rev="${{github.event.pull_request.base.sha}},${{github.event.pull_request.head.sha}}" \
             --url=${{ github.event.repository.clone_url }} \
             --bench-on="${{github.event.pull_request.head.sha}}" \
-            --output-dir=results/ --tune
+            --output-dir=results/ --tune \
+            2>&1 | tee target/mt_results/mt-log.txt
 
       # - name: Create plots from benchmarks
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.9" # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
+          - "1.10" # Replace this with the minimum Julia version that your package supports. E.g. if your package requires Julia 1.5 or higher, change this to '1.5'.
           - "1" # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - "nightly"
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,11 @@ DataStructures = "0.18"
 DocStringExtensions = "0.8, 0.9"
 PrecompileTools = "1.2"
 Reexport = "0.2, 1"
+SciMLTesting = "2.4"
+Documenter = "1"
+Literate = "2"
+SafeTestsets = "0.1"
+Test = "1"
 TermInterface = "0.3.3"
 TimerOutputs = "0.5"
 julia = "1.8"
@@ -26,7 +31,8 @@ julia = "1.8"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Documenter", "SafeTestsets", "Literate"]
+test = ["Test", "Documenter", "SafeTestsets", "Literate", "SciMLTesting"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ SafeTestsets = "0.1"
 Test = "1"
 TermInterface = "0.3.3"
 TimerOutputs = "0.5"
-julia = "1.8"
+julia = "1.10"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Metatheory = "e9d8d322-4543-424a-9be4-0cc815abe26c"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [compat]
-Documenter = "~0.26"
+Documenter = "1"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -32,56 +32,132 @@ Metatheory.ematcher_yield_bidir
 
 ## Library
 
-```@autodocs
-Modules = [Metatheory.Library]
+```@docs
+Metatheory.Library.@commutativity
+Metatheory.Library.@associativity
+Metatheory.Library.@identity_left
+Metatheory.Library.@identity_right
+Metatheory.Library.@distrib_left
+Metatheory.Library.@distrib_right
+Metatheory.Library.@distrib
+Metatheory.Library.@monoid
+Metatheory.Library.@commutative_monoid
+Metatheory.Library.@commutative_group
+Metatheory.Library.@left_associative
+Metatheory.Library.@right_associative
+Metatheory.Library.@inverse_left
+Metatheory.Library.@inverse_right
 ```
 
 ---
 
 ## Syntax
 
-```@autodocs
-Modules = [Metatheory.Syntax]
+```@docs
+Metatheory.Syntax.@rule
+Metatheory.Syntax.@theory
+Metatheory.Syntax.@slots
+Metatheory.Syntax.@capture
 ```
 
 ---
 
 ## Patterns
 
-```@autodocs
-Modules = [Metatheory.Patterns]
+```@docs
+Metatheory.Patterns.AbstractPat
+Metatheory.Patterns.PatVar
+Metatheory.Patterns.PatTerm
+Metatheory.Patterns.PatSegment
+Metatheory.Patterns.patvars
+Metatheory.Patterns.setdebrujin!
+Metatheory.Patterns.isground
+Metatheory.Patterns.UnsupportedPatternException
 ```
 
 ---
 
 ## Rules 
 
-```@autodocs
-Modules = [Metatheory.Rules]
+```@docs
+Metatheory.Rules.SymbolicRule
+Metatheory.Rules.RewriteRule
+Metatheory.Rules.BidirRule
+Metatheory.Rules.EqualityRule
+Metatheory.Rules.UnequalRule
+Metatheory.Rules.DynamicRule
+Metatheory.Rules.AbstractRule
 ```
 
 ---
 
 ## Rewriters
 
-```@autodocs
-Modules = [Metatheory.Rewriters]
+```@docs
+Metatheory.Rewriters.Empty
+Metatheory.Rewriters.IfElse
+Metatheory.Rewriters.If
+Metatheory.Rewriters.Chain
+Metatheory.Rewriters.RestartedChain
+Metatheory.Rewriters.Fixpoint
+Metatheory.Rewriters.Postwalk
+Metatheory.Rewriters.Prewalk
+Metatheory.Rewriters.PassThrough
 ```
 
 ---
 
 ## EGraphs
 
-```@autodocs
-Modules = [Metatheory.EGraphs]
+```@docs
+Metatheory.EGraphs.IntDisjointSet
+Metatheory.EGraphs.in_same_set
+Metatheory.EGraphs.AbstractENode
+Metatheory.EGraphs.ENodeLiteral
+Metatheory.EGraphs.ENodeTerm
+Metatheory.EGraphs.EClassId
+Metatheory.EGraphs.EClass
+Metatheory.EGraphs.hasdata
+Metatheory.EGraphs.getdata
+Metatheory.EGraphs.setdata!
+Metatheory.EGraphs.find
+Metatheory.EGraphs.lookup
+Metatheory.EGraphs.arity
+Metatheory.EGraphs.EGraph
+Metatheory.EGraphs.merge!
+Metatheory.EGraphs.in_same_class
+Metatheory.EGraphs.addexpr!
+Metatheory.EGraphs.rebuild!
+Metatheory.EGraphs.settermtype!
+Metatheory.EGraphs.gettermtype
+Metatheory.EGraphs.analyze!
+Metatheory.EGraphs.extract!
+Metatheory.EGraphs.astsize
+Metatheory.EGraphs.astsize_inv
+Metatheory.EGraphs.getcost!
+Metatheory.EGraphs.SaturationGoal
+Metatheory.EGraphs.EqualityGoal
+Metatheory.EGraphs.reached
+Metatheory.EGraphs.SaturationParams
+Metatheory.EGraphs.saturate!
+Metatheory.EGraphs.areequal
+Metatheory.EGraphs.@areequal
+Metatheory.EGraphs.@areequalg
 ```
 
 ---
 
 ## EGraph Schedulers
 
-```@autodocs
-Modules = [Metatheory.EGraphs.Schedulers]
+```@docs
+Metatheory.EGraphs.Schedulers.AbstractScheduler
+Metatheory.EGraphs.Schedulers.SimpleScheduler
+Metatheory.EGraphs.Schedulers.BackoffScheduler
+Metatheory.EGraphs.Schedulers.ScoredScheduler
+Metatheory.EGraphs.Schedulers.cansaturate
+Metatheory.EGraphs.Schedulers.cansearch
+Metatheory.EGraphs.Schedulers.inform!
+Metatheory.EGraphs.Schedulers.setiter!
 ```
 
 ## EGraph analysis interfaces
@@ -91,7 +167,24 @@ Metatheory.EGraphs.islazy
 Metatheory.EGraphs.modify!
 Metatheory.EGraphs.join
 Metatheory.EGraphs.make
-Metatheory.EGraphs.analyze!
-Metatheory.EGraphs.extract!
 Metatheory.EGraphs.egraph_reconstruct_expression
+Metatheory.binarize_rec
+```
+
+## Developer implementation API
+
+These bindings support custom backends and analyses inside Metatheory's
+implementation. They are documented for package developers; ordinary users
+should prefer the public interfaces above.
+
+```@docs
+Metatheory.Rewriters.FixpointNoCycle
+Metatheory.EGraphs.eqsat_step!
+Metatheory.EGraphs.instantiate_actual_param!
+Metatheory.EGraphs.preprocess
+Metatheory.EGraphs.reachable
+Metatheory.EGraphs.eqsat_search!
+Metatheory.EGraphs.add!
+Metatheory.Syntax.rewrite_rhs
+Metatheory.Syntax.rmlines
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,25 @@
 # API Documentation
 
+## Metatheory
+
+```@docs
+Metatheory
+rewrite
+Metatheory.@matchable
+Metatheory.@timer
+Metatheory.@iftimer
+Metatheory.@timerewrite
+```
+
+---
+
+## Library
+
+```@autodocs
+Modules = [Metatheory.Library]
+```
+
+---
 
 ## Syntax
 
@@ -13,14 +33,6 @@ Modules = [Metatheory.Syntax]
 
 ```@autodocs
 Modules = [Metatheory.Patterns]
-```
-
----
-
-## Rules 
-
-```@autodocs
-Modules = [Metatheory.Rules]
 ```
 
 ---

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,6 +13,23 @@ Metatheory.@timerewrite
 
 ---
 
+## Public modules and matcher compiler
+
+```@docs
+Metatheory.Library
+Metatheory.Syntax
+Metatheory.Patterns
+Metatheory.Rules
+Metatheory.Rewriters
+Metatheory.EGraphs
+Metatheory.EGraphs.Schedulers
+Metatheory.EMatchCompiler
+Metatheory.ematcher_yield
+Metatheory.ematcher_yield_bidir
+```
+
+---
+
 ## Library
 
 ```@autodocs
@@ -65,4 +82,16 @@ Modules = [Metatheory.EGraphs]
 
 ```@autodocs
 Modules = [Metatheory.EGraphs.Schedulers]
+```
+
+## EGraph analysis interfaces
+
+```@docs
+Metatheory.EGraphs.islazy
+Metatheory.EGraphs.modify!
+Metatheory.EGraphs.join
+Metatheory.EGraphs.make
+Metatheory.EGraphs.analyze!
+Metatheory.EGraphs.extract!
+Metatheory.EGraphs.egraph_reconstruct_expression
 ```

--- a/docs/src/egraphs.md
+++ b/docs/src/egraphs.md
@@ -35,7 +35,7 @@ system governed by equational rules, about non obviously oriented equations, suc
 )`?
 
 E-Graphs come to our help. 
-EGraphs are bipartite graphs of [ENode](@ref)s and [EClass](@ref)es:
+EGraphs are bipartite graphs of [`AbstractENode`](@ref Metatheory.EGraphs.AbstractENode)s and [`EClass`](@ref Metatheory.EGraphs.EClass)es:
 a data structure for efficiently represent and rewrite on many equivalent expressions at the same time. A sort of fast data structure for sets of trees. Subtrees and parents are shared if possible. This makes EGraphs similar to DAGs.
 Most importantly, with EGraph rewriting you can use **bidirectional rewrite rules**, such as **equalities** without worrying about
 the ordering and confluence of your rewrite system!
@@ -47,7 +47,7 @@ lost.
 The EGraph backend for Metatheory.jl allows you to create an
 EGraph from a starting expression, to add more expressions to the EGraph with
 `addexpr!`, and then to effectively fill the EGraph with all possible equivalent
-expressions resulting from applying rewrite rules from a [theory](../rewrite#Theories), by using the
+expressions resulting from applying rewrite rules from a [theory](rewrite.md#Theories), by using the
 `saturate!` function. You can then easily extract expressions from an e-graph by calling `extract!` with a cost
 function.
 
@@ -135,9 +135,9 @@ julia> @areequal some_theory (x+y)*(a+b) ((a*(x+y))+b*(x+y)) ((x*(a+b))+y*(a+b))
 
 ## Configurable Parameters
 
-[`EGraphs.saturate!`](@ref) can accept an additional parameter of type
-[`EGraphs.SaturationParams`](@ref) to configure the equality saturation algorithm.
-Extensive documentation for the configurable parameters is available in the [`EGraphs.SaturationParams`](@ref) API docstring.
+[`EGraphs.saturate!`](@ref Metatheory.EGraphs.saturate!) can accept an additional parameter of type
+[`EGraphs.SaturationParams`](@ref Metatheory.EGraphs.SaturationParams) to configure the equality saturation algorithm.
+Extensive documentation for the configurable parameters is available in the [`EGraphs.SaturationParams`](@ref Metatheory.EGraphs.SaturationParams) API docstring.
 
 ```julia
 # create the saturation params
@@ -221,7 +221,7 @@ saturate!(g, t)
 ex = extract!(g, astsize)
 ```
 
-The second argument to `extract!` is a **cost function**. [astsize](@ref) is 
+The second argument to `extract!` is a **cost function**. [`astsize`](@ref Metatheory.EGraphs.astsize) is
 a cost function provided by default, which computes the size of expressions.
 
 
@@ -231,16 +231,16 @@ A *cost function* for *EGraph extraction* is a function used to determine
 which *e-node* will be extracted from an *e-class*. 
 
 It must return a positive, non-complex number value and, must accept 3 arguments.
-1) The current [ENode](@ref) `n` that is being inspected. 
-2) The current [EGraph](@ref) `g`.
+1) The current [`AbstractENode`](@ref Metatheory.EGraphs.AbstractENode) `n` that is being inspected.
+2) The current [`EGraph`](@ref Metatheory.EGraphs.EGraph) `g`.
 3) The current analysis name `an::Symbol`.
 
 From those 3 parameters, one can access all the data needed to compute
 the cost of an e-node recursively.
 
 * One can use [TermInterface.jl](https://github.com/JuliaSymbolics/TermInterface.jl) methods to access the operation and child arguments of an e-node: `operation(n)`, `arity(n)` and `arguments(n)`
-* Since e-node children always point to e-classes in the same e-graph, one can retrieve the [EClass](@ref) object for each child of the currently visited enode with `g[id] for id in arguments(n)`
-* One can inspect the analysis data for a given eclass and a given analysis name `an`, by using [hasdata](@ref) and [getdata](@ref).
+* Since e-node children always point to e-classes in the same e-graph, one can retrieve the [`EClass`](@ref Metatheory.EGraphs.EClass) object for each child of the currently visited enode with `g[id] for id in arguments(n)`
+* One can inspect the analysis data for a given eclass and a given analysis name `an`, by using [`hasdata`](@ref Metatheory.EGraphs.hasdata) and [`getdata`](@ref Metatheory.EGraphs.getdata).
 * Extraction analyses always associate a tuple of 2 values to a single e-class: which e-node is the one that minimizes the cost
 and its cost. More details can be found in the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304) in the *Analyses* section. 
 
@@ -274,7 +274,7 @@ An *EGraph Analysis* is an efficient and automated way of analyzing all the poss
 terms contained in an e-graph. Metatheory.jl provides a toolkit to ease and 
 automate the process of EGraph Analysis. 
 
-An *EGraph Analysis* defines a domain of values and associates a value from the domain to each [EClass](@ref) in the graph. Theoretically, the domain should form a [join semilattice](https://en.wikipedia.org/wiki/Semilattice).  Rewrites can cooperate with e-class analyses by depending on analysis facts and adding equivalences that in turn establish additional facts. 
+An *EGraph Analysis* defines a domain of values and associates a value from the domain to each [`EClass`](@ref Metatheory.EGraphs.EClass) in the graph. Theoretically, the domain should form a [join semilattice](https://en.wikipedia.org/wiki/Semilattice).  Rewrites can cooperate with e-class analyses by depending on analysis facts and adding equivalences that in turn establish additional facts.
 
 In Metatheory.jl, **EGraph Analyses are uniquely identified** by either
 
@@ -284,10 +284,10 @@ In Metatheory.jl, **EGraph Analyses are uniquely identified** by either
 If you are specifying a custom analysis by its `Symbol` name, 
 the following functions define an interface for analyses based on multiple dispatch 
 on `Val{analysis_name::Symbol}`: 
-* [islazy(an)](@ref) should return true if the analysis name `an` should NOT be computed on-the-fly during egraphs operation, but only when inspected.  
-* [make(an, egraph, n)](@ref) should take an ENode `n` and return a value from the analysis domain.
-* [join(an, x,y)](@ref) should return the semilattice join of `x` and `y` in the analysis domain (e.g. *given two analyses value from ENodes in the same EClass, which one should I choose?*). If `an` is a `Function`, it is treated as a cost function analysis, it is automatically defined to be the minimum analysis value between `x` and `y`. Typically, the domain value of cost functions are real numbers, but if you really do want to have your own cost type, make sure that `Base.isless` is defined.
-* [modify!(an, egraph, eclassid)](@ref) Can be optionally implemented. This can be used modify an EClass `egraph[eclassid]` on-the-fly during an e-graph saturation iteration, given its analysis value.
+* [`islazy`](@ref Metatheory.EGraphs.islazy) should return true if the analysis name `an` should NOT be computed on-the-fly during egraphs operation, but only when inspected.
+* [`make`](@ref Metatheory.EGraphs.make) should take an [`AbstractENode`](@ref Metatheory.EGraphs.AbstractENode) `n` and return a value from the analysis domain.
+* [`join`](@ref Metatheory.EGraphs.join) should return the semilattice join of `x` and `y` in the analysis domain (e.g. *given two analyses value from ENodes in the same EClass, which one should I choose?*). If `an` is a `Function`, it is treated as a cost function analysis, it is automatically defined to be the minimum analysis value between `x` and `y`. Typically, the domain value of cost functions are real numbers, but if you really do want to have your own cost type, make sure that `Base.isless` is defined.
+* [`modify!`](@ref Metatheory.EGraphs.modify!) can be optionally implemented. This can be used modify an EClass `egraph[eclassid]` on-the-fly during an e-graph saturation iteration, given its analysis value.
 
 ### Defining a custom analysis
 
@@ -309,7 +309,7 @@ using Metatheory.EGraphs
 ```
 
 The next step, the base case of induction, is to define a method for
-[make](@ref) dispatching against our `OddEvenAnalysis`. First, we want to
+[`make`](@ref Metatheory.EGraphs.make) dispatching against our `OddEvenAnalysis`. First, we want to
 associate an analysis value only to the *literals* contained in the EGraph. To do this we
 take advantage of multiple dispatch against `ENodeLiteral`.
 
@@ -338,7 +338,7 @@ We can now define a method for `make` dispatching against
 `OddEvenAnalysis` and `ENodeTerm`s to compute the analysis value for *nested* symbolic terms. 
 We take advantage of the methods in [TermInterface](https://github.com/JuliaSymbolics/TermInterface.jl) 
 to inspect the content of an `ENodeTerm`.
-From the definition of an [ENode](@ref), we know that children of ENodes are always IDs pointing
+From the definition of an [`AbstractENode`](@ref Metatheory.EGraphs.AbstractENode), we know that children of ENodes are always IDs pointing
 to EClasses in the EGraph.
 
 ```julia
@@ -380,11 +380,11 @@ end
 ```
 
 We have now defined a way of tagging each ENode in the EGraph with `:odd` or `:even`, reasoning 
-inductively on the analyses values. The [analyze!](@ref) function will do the dirty job of doing 
+inductively on the analyses values. The [`analyze!`](@ref Metatheory.EGraphs.analyze!) function will do the dirty job of doing
 a recursive walk over the EGraph. The missing piece, is now telling Metatheory.jl how to merge together
 analysis values. Since EClasses represent many equal ENodes, we have to inform the automated analysis
 how to extract a single value out of the many analyses values contained in an EGraph.
-We do this by defining a method for [join](@ref).
+We do this by defining a method for [`join`](@ref Metatheory.EGraphs.join).
 
 ```julia
 function EGraphs.join(::Val{:OddEvenAnalysis}, a, b)
@@ -399,7 +399,7 @@ end
 ```
 
 We do not care to modify the content of EClasses in consequence of our analysis.
-Therefore, we can skip the definition of [modify!](@ref).
+Therefore, we can skip the definition of [`modify!`](@ref Metatheory.EGraphs.modify!).
 We are now ready to test our analysis.
 
 ```julia

--- a/docs/src/egraphs.md
+++ b/docs/src/egraphs.md
@@ -110,6 +110,15 @@ customizable parameters include a `timeout` on the number of iterations, a
 that stops saturation when it evaluates to true.
 
 ```@example
+using Metatheory
+using Metatheory.EGraphs
+
+t = @theory a b c begin
+    a * b == b * a
+    a * 1 == a
+    a * (b * c) == (a * b) * c
+end
+
 g = EGraph(:((a * b) * (1 * (b + c))));
 report = saturate!(g, t);
 ```

--- a/docs/src/visualizing.md
+++ b/docs/src/visualizing.md
@@ -38,4 +38,4 @@ g
 
 And you will see a nice e-graph drawing in the Julia Plots VSCode panel:
 
-![E-Graph Drawing](/assets/graphviz.svg)
+![E-Graph Drawing](assets/graphviz.svg)

--- a/examples/propositional_logic_theory.jl
+++ b/examples/propositional_logic_theory.jl
@@ -25,12 +25,16 @@ and_alg = @theory p q r begin
 end
 
 comb = @theory p q r begin
+  #= DeMorgan =#
   !(p || q) == (!p && !q)
   !(p && q) == (!p || !q)
+  #= distrib =#
   (p && (q || r)) == ((p && q) || (p && r))
   (p || (q && r)) == ((p || q) && (p || r))
+  #= absorb =#
   (p && (p || q)) --> p
   (p || (p && q)) --> p
+  #= complement =#
   (p && (!p || q)) --> p && q
   (p || (!p && q)) --> p || q
 end

--- a/examples/propositional_logic_theory.jl
+++ b/examples/propositional_logic_theory.jl
@@ -25,16 +25,12 @@ and_alg = @theory p q r begin
 end
 
 comb = @theory p q r begin
-  # DeMorgan
   !(p || q) == (!p && !q)
   !(p && q) == (!p || !q)
-  # distrib
   (p && (q || r)) == ((p && q) || (p && r))
   (p || (q && r)) == ((p || q) && (p || r))
-  # absorb
   (p && (p || q)) --> p
   (p || (p && q)) --> p
-  # complement
   (p && (!p || q)) --> p && q
   (p || (!p && q)) --> p || q
 end
@@ -90,4 +86,3 @@ function prove(
   end
   return ex
 end
-

--- a/src/EGraphs/EGraphs.jl
+++ b/src/EGraphs/EGraphs.jl
@@ -12,13 +12,12 @@ module EGraphs
 
 include("../docstrings.jl")
 
-using DataStructures
-using TermInterface
-using TimerOutputs
-using Metatheory: alwaystrue, cleanast, binarize
-using Metatheory.Patterns
-using Metatheory.Rules
-using Metatheory.EMatchCompiler
+import DataStructures: CircularDeque, LittleDict, OrderedDict
+import TermInterface: arguments, arity, exprhead, istree, operation, similarterm, symtype
+import TimerOutputs: @timeit, TimerOutput, disable_timer!, print_timer
+import Metatheory: cleanast
+import Metatheory.Patterns: AbstractPat, PatTerm, PatVar, UnsupportedPatternException, isground
+import Metatheory.Rules: AbstractRule, BidirRule, DynamicRule, EqualityRule, RewriteRule, UnequalRule
 
 include("intdisjointmap.jl")
 export IntDisjointSet
@@ -53,7 +52,7 @@ export getcost!
 
 include("Schedulers.jl")
 export Schedulers
-using .Schedulers
+import .Schedulers: AbstractScheduler, BackoffScheduler, cansaturate, cansearch, inform!, setiter!
 
 include("saturation.jl")
 export SaturationGoal

--- a/src/EGraphs/EGraphs.jl
+++ b/src/EGraphs/EGraphs.jl
@@ -4,8 +4,8 @@
 Equality graphs for retaining and saturating many equivalent representations
 of a term.
 
-Build an [`EGraph`](@ref), add terms with [`addexpr!`](@ref), and call
-[`saturate!`](@ref) with a rule theory. Custom analyses implement the generic
+Build an [`EGraph`](@ref Metatheory.EGraphs.EGraph), add terms with [`addexpr!`](@ref Metatheory.EGraphs.addexpr!), and call
+[`saturate!`](@ref Metatheory.EGraphs.saturate!) with a rule theory. Custom analyses implement the generic
 `make`, `join`, `modify!`, and `islazy` hooks documented in the analysis API.
 """
 module EGraphs
@@ -18,6 +18,14 @@ import TimerOutputs: TimerOutput, disable_timer!, print_timer, timeit
 import Metatheory: cleanast
 import Metatheory.Patterns: AbstractPat, PatTerm, PatVar, UnsupportedPatternException, isground
 import Metatheory.Rules: AbstractRule, BidirRule, DynamicRule, EqualityRule, RewriteRule, UnequalRule
+
+"""
+    arity(term)
+
+Return the number of child arguments in a term. This is the
+TermInterface.arity function reexported for e-graph implementations.
+"""
+arity
 
 include("intdisjointmap.jl")
 export IntDisjointSet

--- a/src/EGraphs/EGraphs.jl
+++ b/src/EGraphs/EGraphs.jl
@@ -14,7 +14,7 @@ include("../docstrings.jl")
 
 import DataStructures: CircularDeque, LittleDict, OrderedDict
 import TermInterface: arguments, arity, exprhead, istree, operation, similarterm, symtype
-import TimerOutputs: @timeit, TimerOutput, disable_timer!, print_timer
+import TimerOutputs: TimerOutput, disable_timer!, print_timer, timeit
 import Metatheory: cleanast
 import Metatheory.Patterns: AbstractPat, PatTerm, PatVar, UnsupportedPatternException, isground
 import Metatheory.Rules: AbstractRule, BidirRule, DynamicRule, EqualityRule, RewriteRule, UnequalRule

--- a/src/EGraphs/EGraphs.jl
+++ b/src/EGraphs/EGraphs.jl
@@ -1,3 +1,13 @@
+"""
+    EGraphs
+
+Equality graphs for retaining and saturating many equivalent representations
+of a term.
+
+Build an [`EGraph`](@ref), add terms with [`addexpr!`](@ref), and call
+[`saturate!`](@ref) with a rule theory. Custom analyses implement the generic
+`make`, `join`, `modify!`, and `islazy` hooks documented in the analysis API.
+"""
 module EGraphs
 
 include("../docstrings.jl")
@@ -40,8 +50,6 @@ export extract!
 export astsize
 export astsize_inv
 export getcost!
-
-export Sub
 
 include("Schedulers.jl")
 export Schedulers

--- a/src/EGraphs/Schedulers.jl
+++ b/src/EGraphs/Schedulers.jl
@@ -10,10 +10,9 @@ module Schedulers
 
 include("../docstrings.jl")
 
-using Metatheory.Rules
-using Metatheory.EGraphs
-using Metatheory.Patterns
-using DocStringExtensions
+import Metatheory.Rules: AbstractRule, DynamicRule
+import Metatheory.EGraphs: EGraph
+import Metatheory.Patterns: PatTerm
 
 export AbstractScheduler
 export SimpleScheduler
@@ -83,7 +82,15 @@ function setiter! end
 
 
 """
-A simple Rewrite Scheduler that applies every rule every time
+    SimpleScheduler()
+
+A scheduler that searches every rule on every iteration and never stops due to
+scheduler state. It is useful as a reference implementation for custom
+schedulers and for small theories.
+
+The scheduler constructor used by [`saturate!`](@ref) is
+`SimpleScheduler(egraph, theory)`; the arguments are accepted for interface
+compatibility and are not stored.
 """
 struct SimpleScheduler <: AbstractScheduler end
 
@@ -108,14 +115,23 @@ mutable struct BackoffSchedulerEntry
 end
 
 """
-A Rewrite Scheduler that implements exponential rule backoff.
-For each rewrite, there exists a configurable initial match limit.
-If a rewrite search yield more than this limit, then we ban this rule
-for number of iterations, double its limit, and double the time it
-will be banned next time.
+    BackoffScheduler(egraph, theory[, match_limit, ban_length])
 
-This seems effective at preventing explosive rules like
-associativity from taking an unfair amount of resources.
+A scheduler that applies exponential rule backoff. When a rule yields more
+than its match limit, it is skipped for a number of iterations; both limits
+grow after each ban. This bounds explosive theories such as associativity.
+
+# Arguments
+
+- `egraph`: E-graph being saturated.
+- `theory`: Rules being searched.
+- `match_limit::Int=1000`: Initial matches permitted for one rule.
+- `ban_length::Int=5`: Initial number of iterations to skip after a ban.
+
+# Fields
+
+- `data`: Per-rule backoff state.
+- `G`, `theory`, `curr_iter`: E-graph, rule collection, and iteration state.
 """
 mutable struct BackoffScheduler <: AbstractScheduler
   data::IdDict{AbstractRule,BackoffSchedulerEntry}
@@ -149,8 +165,8 @@ cansaturate(s::BackoffScheduler)::Bool = all(kv -> s.curr_iter > last(kv).banned
 
 function inform!(s::BackoffScheduler, rule::AbstractRule, n_matches)
   rd = s.data[rule]
-  treshold = rd.match_limit << rd.times_banned
-  if n_matches > treshold
+  threshold = rd.match_limit << rd.times_banned
+  if n_matches > threshold
     ban_length = rd.ban_length << rd.times_banned
     rd.times_banned += 1
     rd.banned_until = s.curr_iter + ban_length
@@ -177,14 +193,24 @@ mutable struct ScoredSchedulerEntry
 end
 
 """
-A Rewrite Scheduler that implements exponential rule backoff.
-For each rewrite, there exists a configurable initial match limit.
-If a rewrite search yield more than this limit, then we ban this rule
-for number of iterations, double its limit, and double the time it
-will be banned next time.
+    ScoredScheduler(egraph, theory[, match_limit, ban_length, complexity])
 
-This seems effective at preventing explosive rules like
-associativity from taking an unfair amount of resources.
+A backoff scheduler that weights rules by how their complexity changes. Rules
+that increase expression complexity are penalized more heavily than rules that
+reduce it.
+
+# Arguments
+
+- `egraph`: E-graph being saturated.
+- `theory`: Rules being searched.
+- `match_limit::Int=1000`: Initial matches permitted for one rule.
+- `ban_length::Int=5`: Initial number of iterations to skip after a ban.
+- `complexity`: Callable returning a comparable complexity score for a pattern.
+
+# Fields
+
+- `data`: Per-rule match limits, weights, and ban state.
+- `G`, `theory`, `curr_iter`: E-graph, rule collection, and iteration state.
 """
 mutable struct ScoredScheduler <: AbstractScheduler
   data::IdDict{AbstractRule,ScoredSchedulerEntry}
@@ -260,8 +286,8 @@ cansaturate(s::ScoredScheduler)::Bool = all(kv -> s.curr_iter > last(kv).banned_
 
 function inform!(s::ScoredScheduler, rule::AbstractRule, n_matches)
   rd = s.data[rule]
-  treshold = rd.match_limit * (rd.weight^rd.times_banned)
-  if n_matches > treshold
+  threshold = rd.match_limit * (rd.weight^rd.times_banned)
+  if n_matches > threshold
     ban_length = rd.ban_length * (rd.weight^rd.times_banned)
     rd.times_banned += 1
     rd.banned_until = s.curr_iter + ban_length

--- a/src/EGraphs/Schedulers.jl
+++ b/src/EGraphs/Schedulers.jl
@@ -1,3 +1,11 @@
+"""
+    Schedulers
+
+Scheduler implementations for e-graph rule search.
+
+Custom schedulers subtype [`AbstractScheduler`](@ref) and implement
+`cansaturate`, `cansearch`, `inform!`, and `setiter!`.
+"""
 module Schedulers
 
 include("../docstrings.jl")
@@ -17,37 +25,56 @@ export inform!
 export setiter!
 
 """
-Represents a rule scheduler for the equality saturation process
+    AbstractScheduler
 
+Abstract interface for controlling rule search during [`saturate!`](@ref).
+
+A custom scheduler must provide a constructor accepting an [`EGraph`](@ref)
+and a vector of [`AbstractRule`](@ref)s, plus methods for [`cansaturate`](@ref),
+[`cansearch`](@ref), [`inform!`](@ref), and [`setiter!`](@ref). The scheduler
+may keep mutable state, but it must return a Boolean from the first three hooks.
 """
 abstract type AbstractScheduler end
 
 """
-Should return `true` if the e-graph can be said to be saturated
-```
-cansaturate(s::AbstractScheduler)
-```
+    cansaturate(scheduler) -> Bool
+
+Return `true` when the scheduler has no rule search left to perform. This is
+checked after each saturation iteration; returning `false` lets another stop
+condition, such as a goal or timeout, decide when to stop.
+
+Implement this method for custom [`AbstractScheduler`](@ref) types.
 """
 function cansaturate end
 
 """
-Should return `false` if the rule `r` should be skipped
-```
-cansearch(s::AbstractScheduler, r::Rule)
-```
+    cansearch(scheduler, rule) -> Bool
+
+Return `true` when `rule` should be searched during the current iteration and
+`false` when the scheduler wants to skip it.
+
+Implement this method for custom [`AbstractScheduler`](@ref) types.
 """
 function cansearch end
 
 """
-This function is called **after** pattern matching on the e-graph,
-informs the scheduler about the yielded matches.
-Returns `false` if the matches should not be yielded and ignored. 
-```
-inform!(s::AbstractScheduler, r::AbstractRule, n_matches)
-```
+    inform!(scheduler, rule, n_matches) -> Bool
+
+Notify the scheduler how many matches were produced for `rule` in the current
+iteration. Return `true` to keep the matches and `false` to discard them.
+
+Implement this method for custom [`AbstractScheduler`](@ref) types.
 """
 function inform! end
 
+"""
+    setiter!(scheduler, iteration)
+
+Notify a scheduler that saturation has advanced to `iteration`.
+
+Custom schedulers should update any state used by `cansearch` or
+`cansaturate`. The default scheduler interface returns `nothing`.
+"""
 function setiter! end
 
 # ===========================================================================

--- a/src/EGraphs/Schedulers.jl
+++ b/src/EGraphs/Schedulers.jl
@@ -3,7 +3,7 @@
 
 Scheduler implementations for e-graph rule search.
 
-Custom schedulers subtype [`AbstractScheduler`](@ref) and implement
+Custom schedulers subtype [`AbstractScheduler`](@ref Metatheory.EGraphs.Schedulers.AbstractScheduler) and implement
 `cansaturate`, `cansearch`, `inform!`, and `setiter!`.
 """
 module Schedulers
@@ -26,11 +26,11 @@ export setiter!
 """
     AbstractScheduler
 
-Abstract interface for controlling rule search during [`saturate!`](@ref).
+Abstract interface for controlling rule search during [`saturate!`](@ref Metatheory.EGraphs.saturate!).
 
-A custom scheduler must provide a constructor accepting an [`EGraph`](@ref)
-and a vector of [`AbstractRule`](@ref)s, plus methods for [`cansaturate`](@ref),
-[`cansearch`](@ref), [`inform!`](@ref), and [`setiter!`](@ref). The scheduler
+A custom scheduler must provide a constructor accepting an [`EGraph`](@ref Metatheory.EGraphs.EGraph)
+and a vector of [`AbstractRule`](@ref Metatheory.Rules.AbstractRule)s, plus methods for [`cansaturate`](@ref Metatheory.EGraphs.Schedulers.cansaturate),
+[`cansearch`](@ref Metatheory.EGraphs.Schedulers.cansearch), [`inform!`](@ref Metatheory.EGraphs.Schedulers.inform!), and [`setiter!`](@ref Metatheory.EGraphs.Schedulers.setiter!). The scheduler
 may keep mutable state, but it must return a Boolean from the first three hooks.
 """
 abstract type AbstractScheduler end
@@ -42,7 +42,7 @@ Return `true` when the scheduler has no rule search left to perform. This is
 checked after each saturation iteration; returning `false` lets another stop
 condition, such as a goal or timeout, decide when to stop.
 
-Implement this method for custom [`AbstractScheduler`](@ref) types.
+Implement this method for custom [`AbstractScheduler`](@ref Metatheory.EGraphs.Schedulers.AbstractScheduler) types.
 """
 function cansaturate end
 
@@ -52,7 +52,7 @@ function cansaturate end
 Return `true` when `rule` should be searched during the current iteration and
 `false` when the scheduler wants to skip it.
 
-Implement this method for custom [`AbstractScheduler`](@ref) types.
+Implement this method for custom [`AbstractScheduler`](@ref Metatheory.EGraphs.Schedulers.AbstractScheduler) types.
 """
 function cansearch end
 
@@ -62,7 +62,7 @@ function cansearch end
 Notify the scheduler how many matches were produced for `rule` in the current
 iteration. Return `true` to keep the matches and `false` to discard them.
 
-Implement this method for custom [`AbstractScheduler`](@ref) types.
+Implement this method for custom [`AbstractScheduler`](@ref Metatheory.EGraphs.Schedulers.AbstractScheduler) types.
 """
 function inform! end
 
@@ -88,7 +88,7 @@ A scheduler that searches every rule on every iteration and never stops due to
 scheduler state. It is useful as a reference implementation for custom
 schedulers and for small theories.
 
-The scheduler constructor used by [`saturate!`](@ref) is
+The scheduler constructor used by [`saturate!`](@ref Metatheory.EGraphs.saturate!) is
 `SimpleScheduler(egraph, theory)`; the arguments are accepted for interface
 compatibility and are not stored.
 """

--- a/src/EGraphs/analysis.jl
+++ b/src/EGraphs/analysis.jl
@@ -46,7 +46,7 @@ join(an, a, b) = join(analysis_reference(an), a, b)
 Return the analysis value contributed by e-node `n` in `g`. The value is then
 combined with other values by [`join`](@ref).
 
-# Example
+# Examples
 
 ```julia
 Metatheory.EGraphs.make(::Val{:constant}, g, node) =
@@ -189,7 +189,7 @@ Extract the expression with the smallest `costfun` value from `egraph`.
 - `egraph`: Graph to analyze and extract from.
 - `costfun`: Function of `(enode, egraph)` returning a numeric cost.
 
-# Keyword Arguments
+# Keywords
 
 - `root::EClassId=-1`: Root e-class; `-1` uses `egraph.root`.
 - `cse::Bool=false`: Return a `let` expression that names repeated
@@ -245,7 +245,7 @@ Compute and return the minimum cost of the root e-class according to
 - `g`: E-graph to analyze.
 - `costfun`: Function receiving `(enode, g)` and returning a numeric cost.
 
-# Keyword Arguments
+# Keywords
 
 - `root::EClassId=-1`: Root e-class; `-1` uses `g.root`.
 

--- a/src/EGraphs/analysis.jl
+++ b/src/EGraphs/analysis.jl
@@ -199,6 +199,23 @@ function collect_cse!(g::EGraph, costfun, id, cse_env, seen)
 end
 
 
+"""
+    getcost!(g, costfun; root=-1)
+
+Compute and return the minimum cost of the root e-class according to
+`costfun`.
+
+# Arguments
+
+- `g`: E-graph to analyze.
+- `costfun`: Function receiving `(enode, g)` and returning a numeric cost.
+
+# Keyword Arguments
+
+- `root::EClassId=-1`: Root e-class; `-1` uses `g.root`.
+
+The analysis data in `g` is updated in place.
+"""
 function getcost!(g::EGraph, costfun; root = -1)
   if root == -1
     root = g.root

--- a/src/EGraphs/analysis.jl
+++ b/src/EGraphs/analysis.jl
@@ -5,11 +5,12 @@ analysis_reference(x) = error("$x is not a valid analysis reference")
 """
     islazy(::Val{analysis_name})
 
-Should return `true` if the EGraph Analysis `an` is lazy
-and false otherwise. A *lazy* EGraph Analysis is computed 
-only when [analyze!](@ref) is called. *Non-lazy* 
-analyses are instead computed on-the-fly every time ENodes are added to the EGraph or
-EClasses are merged.  
+Return whether an analysis is lazy. A lazy analysis is computed only when
+[`analyze!`](@ref) is called; a non-lazy analysis is updated as e-nodes are
+inserted and e-classes are merged.
+
+Extend `islazy(::Val{:name})` for a custom symbolic analysis. Cost functions
+are lazy by default.
 """
 islazy(::Val{analysis_name}) where {analysis_name} = false
 islazy(analysis_name) = islazy(analysis_reference(analysis_name))
@@ -17,10 +18,11 @@ islazy(analysis_name) = islazy(analysis_reference(analysis_name))
 """
     modify!(::Val{analysis_name}, g, id)
 
-The `modify!` function for EGraph Analysis can optionally modify the eclass
-`g[id]` after it has been analyzed, typically by adding an ENode.
-It should be **idempotent** if no other changes occur to the EClass. 
-(See the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304)).
+Optionally modify `g[id]` after an analysis value has been computed, typically
+by adding an e-node. The method must be idempotent when the e-class has not
+otherwise changed, or saturation can fail to converge.
+
+Return `nothing` when no modification is needed.
 """
 modify!(::Val{analysis_name}, g, id) where {analysis_name} = nothing
 modify!(an, g, id) = modify!(analysis_reference(an), g, id)
@@ -29,8 +31,10 @@ modify!(an, g, id) = modify!(analysis_reference(an), g, id)
 """
     join(::Val{analysis_name}, a, b)
 
-Joins two analyses values into a single one, used by [analyze!](@ref)
-when two eclasses are being merged or the analysis is being constructed.
+Combine two analysis values into one value in the analysis domain. The method
+is used when e-classes merge and when an e-class contains multiple e-nodes.
+It should be associative and, when the analysis is a semilattice, commutative
+and idempotent.
 """
 join(analysis::Val{analysis_name}, a, b) where {analysis_name} =
   error("Analysis $analysis_name does not implement join")
@@ -39,7 +43,16 @@ join(an, a, b) = join(analysis_reference(an), a, b)
 """
     make(::Val{analysis_name}, g, n)
 
-Given an ENode `n`, `make` should return the corresponding analysis value. 
+Return the analysis value contributed by e-node `n` in `g`. The value is then
+combined with other values by [`join`](@ref).
+
+# Example
+
+```julia
+Metatheory.EGraphs.make(::Val{:constant}, g, node) =
+    node isa ENodeLiteral ? node.value : nothing
+Metatheory.EGraphs.join(::Val{:constant}, a, b) = a == b ? a : nothing
+```
 """
 make(::Val{analysis_name}, g, n) where {analysis_name} = error("Analysis $analysis_name does not implement make")
 make(an, g, n) = make(analysis_reference(an), g, n)
@@ -51,12 +64,16 @@ analyze!(g::EGraph, analysis_ref) = analyze!(g, analysis_ref, collect(keys(g.cla
 """
     analyze!(egraph, analysis_name, [ECLASS_IDS])
 
-Given an [EGraph](@ref) and an `analysis` identified by name `analysis_name`, 
-do an automated bottom up trasversal of the EGraph, associating a value from the 
-domain of analysis to each ENode in the egraph by the [make](@ref) function. 
-Then, for each [EClass](@ref), compute the [join](@ref) of the children ENodes analyses values.
-After `analyze!` is called, an analysis value will be associated to each EClass in the EGraph.
-One can inspect and retrieve analysis values by using [hasdata](@ref) and [getdata](@ref).
+Run a bottom-up analysis over the e-graph. `analysis_ref` may be a symbol or a
+function; `ids` optionally restricts the traversal to selected reachable
+e-classes. The analysis uses [`make`](@ref) for each e-node and [`join`](@ref)
+to combine values, then stores the result for [`getdata`](@ref).
+
+# Arguments
+
+- `egraph`: Graph to analyze in place.
+- `analysis_ref`: Symbolic analysis name or cost function.
+- `ids`: Optional vector of root e-class identifiers.
 """
 function analyze!(g::EGraph, analysis_ref, ids::Vector{EClassId})
   addanalysis!(g, analysis_ref)
@@ -92,8 +109,10 @@ function analyze!(g::EGraph, analysis_ref, ids::Vector{EClassId})
 end
 
 """
-A basic cost function, where the computed cost is the size
-(number of children) of the current expression.
+    astsize(enode, egraph) -> Int
+
+Return a cost equal to one plus the number of child e-nodes, plus the cost of
+each child. This is the default small-expression extraction heuristic.
 """
 function astsize(n::ENodeTerm, g::EGraph)
   cost = 1 + arity(n)
@@ -108,9 +127,10 @@ end
 astsize(n::ENodeLiteral, g::EGraph) = 1
 
 """
-A basic cost function, where the computed cost is the size
-(number of children) of the current expression, times -1.
-Strives to get the largest expression
+    astsize_inv(enode, egraph) -> Int
+
+Return the negative of [`astsize`](@ref), causing extraction to prefer larger
+expressions instead of smaller ones.
 """
 function astsize_inv(n::ENodeTerm, g::EGraph)
   cost = -(1 + arity(n)) # minus sign here is the only difference vs astsize
@@ -126,7 +146,10 @@ astsize_inv(n::ENodeLiteral, g::EGraph) = -1
 
 
 """
-When passing a function to analysis functions it is considered as a cost function
+    make(costfun, egraph, enode)
+
+Adapt a cost function to the analysis interface. The returned pair contains
+the original e-node and its numeric cost.
 """
 make(f::Function, g::EGraph, n::AbstractENode) = (n, f(n, g))
 
@@ -157,8 +180,20 @@ function rec_extract(g::EGraph, costfun, id::EClassId; cse_env = nothing)
 end
 
 """
-Given a cost function, extract the expression
-with the smallest computed cost from an [`EGraph`](@ref)
+    extract!(egraph, costfun; root=-1, cse=false)
+
+Extract the expression with the smallest `costfun` value from `egraph`.
+
+# Arguments
+
+- `egraph`: Graph to analyze and extract from.
+- `costfun`: Function of `(enode, egraph)` returning a numeric cost.
+
+# Keyword Arguments
+
+- `root::EClassId=-1`: Root e-class; `-1` uses `egraph.root`.
+- `cse::Bool=false`: Return a `let` expression that names repeated
+  subexpressions when `true`.
 """
 function extract!(g::EGraph, costfun::Function; root = -1, cse = false)
   if root == -1

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -14,6 +14,7 @@ the TermInterface methods `istree`, `operation`, `arguments`, `arity`, and
 abstract type AbstractENode end
 
 import Metatheory: maybelock!
+import TermInterface
 
 const AnalysisData = NamedTuple{N,T} where {N,T<:Tuple}
 """
@@ -252,9 +253,30 @@ function funs_arity(a::EClass)
 end
 
 """
-A concrete type representing an [`EGraph`].
-See the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304)
-for implementation details.
+    EGraph
+
+Mutable equality graph containing e-classes, e-nodes, rewrite analyses, and
+the memoization state needed to maintain congruence closure.
+
+Use [`EGraph(expr)`](@ref) to build a graph from a term. Use the zero-argument
+constructor when the graph will be populated incrementally with
+[`addexpr!`](@ref).
+
+# Fields
+
+- `uf`: Union-find structure for canonical e-class identifiers.
+- `classes`: E-class storage indexed by [`EClassId`](@ref).
+- `memo`: Hash-consing table for canonical e-nodes.
+- `dirty`: E-classes awaiting invariant repair.
+- `root`: Root e-class identifier for the initial expression.
+- `analyses`: Registered analysis functions and names.
+- `symcache`: Operation-to-e-class index used by matching.
+- `default_termtype`, `termtypes`: Types used to reconstruct extracted terms.
+- `numclasses`, `numnodes`: Current graph size counters.
+- `needslock`, `buffer`, `merges_buffer`, `lock`: Matching and merge workspaces.
+
+See the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304) for the
+congruence-closure design used by this implementation.
 """
 mutable struct EGraph
   "stores the equality relations over e-class ids"
@@ -285,8 +307,17 @@ end
 
 
 """
-    EGraph(expr)
-Construct an EGraph from a starting symbolic expression `expr`.
+    EGraph(; needslock=false, buffer_size=DEFAULT_BUFFER_SIZE)
+
+Construct an empty equality graph.
+
+# Arguments
+
+- `needslock::Bool=false`: Use the graph's lock around shared matching and
+  merge buffers.
+- `buffer_size`: Initial capacity requested for matching buffers.
+
+Use [`addexpr!`](@ref) to insert expressions after construction.
 """
 function EGraph(; needslock::Bool = false, buffer_size = DEFAULT_BUFFER_SIZE)
   EGraph(
@@ -312,6 +343,30 @@ function maybelock!(f::Function, g::EGraph)
   g.needslock ? lock(f, g.buffer_lock) : f()
 end
 
+"""
+    EGraph(expr; keepmeta=false, kwargs...)
+
+Construct an [`EGraph`](@ref) containing `expr` and return it with `expr` as
+its root e-class.
+
+# Arguments
+
+- `expr`: A term accepted by the `TermInterface` traversal used by
+  [`addexpr!`](@ref).
+
+# Keyword Arguments
+
+- `keepmeta::Bool=false`: Preserve term metadata through the metadata analysis.
+- `needslock`, `buffer_size`: Forwarded to the empty-graph constructor.
+
+# Example
+
+```julia
+g = EGraph(:(x + 1))
+root = g.root
+g[root]
+```
+"""
 function EGraph(e; keepmeta = false, kwargs...)
   g = EGraph(kwargs...)
   keepmeta && addanalysis!(g, :metadata_analysis)
@@ -358,7 +413,11 @@ end
 
 
 """
-Returns the canonical e-class id for a given e-class.
+    find(egraph, eclass_or_id) -> EClassId
+
+Return the canonical e-class identifier for an [`EClass`](@ref) or
+[`EClassId`](@ref). The result is the representative used by the e-graph
+after union-find path compression.
 """
 find(g::EGraph, a::EClassId)::EClassId = find_root(g.uf, a)
 find(g::EGraph, a::EClass)::EClassId = find(g, a.id)
@@ -455,9 +514,25 @@ end
 preprocess(x) = x
 
 """
-Recursively traverse an type satisfying the `TermInterface` and insert terms into an
-[`EGraph`](@ref). If `e` has no children (has an arity of 0) then directly
-insert the literal into the [`EGraph`](@ref).
+    addexpr!(egraph, expr; keepmeta=false) -> EClassId
+
+Recursively traverse `expr` using `TermInterface` and insert its terms into the
+[`EGraph`](@ref). A zero-arity term is inserted as an [`ENodeLiteral`](@ref);
+compound terms are hash-consed as [`ENodeTerm`](@ref) values.
+
+# Arguments
+
+- `egraph`: Graph to mutate.
+- `expr`: Term accepted by the `TermInterface` interface.
+
+# Keyword Arguments
+
+- `keepmeta::Bool=false`: Preserve metadata for later reconstruction.
+
+# Returns
+
+The e-class identifier containing the inserted expression. Calling this on an
+equivalent expression returns the existing canonical class.
 """
 function addexpr!(g::EGraph, se; keepmeta = false)::EClassId
   e = preprocess(se)
@@ -482,8 +557,14 @@ function addexpr!(g::EGraph, ec::EClass; keepmeta = false)
 end
 
 """
-Given an [`EGraph`](@ref) and two e-class ids, set
-the two e-classes as equal.
+    merge!(egraph, left, right) -> EClassId
+
+Merge the e-classes identified by `left` and `right`, preserving their
+analysis data and scheduling congruence repair. The returned identifier is the
+canonical representative after the union.
+
+Call [`rebuild!`](@ref) before relying on all congruence invariants or running
+matching over the result.
 """
 function Base.merge!(g::EGraph, a::EClassId, b::EClassId)::EClassId
   id_a = find(g, a)
@@ -521,10 +602,15 @@ end
 
 # TODO new rebuilding from egg
 """
-This function restores invariants and executes
-upwards merging in an [`EGraph`](@ref). See
-the [egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304)
-for more details.
+    rebuild!(egraph) -> EGraph
+
+Restore e-graph congruence invariants after calls to [`merge!`](@ref) and
+perform the pending upward merges. This is the operation that makes newly
+equivalent compound terms discoverable by lookup and matching.
+
+The graph is mutated in place and returned for convenient chaining. See the
+[egg paper](https://dl.acm.org/doi/pdf/10.1145/3434304) for the underlying
+rebuild algorithm.
 """
 function rebuild!(g::EGraph)
   # normalize!(g.uf)
@@ -630,9 +716,33 @@ end
 
 
 """
-When extracting symbolic expressions from an e-graph, we need 
-to instruct the e-graph how to rebuild expressions of a certain type. 
-This function must be extended by the user to add new types of expressions that can be manipulated by e-graphs.
+    egraph_reconstruct_expression(T, operation, args; metadata=nothing,
+        exprhead=:call)
+
+Reconstruct an extracted expression of type `T` from an operation and its
+children. Extend this function for a term type that [`extract!`](@ref) must
+produce; the default methods handle `Expr` values.
+
+# Arguments
+
+- `T`: Target term type.
+- `operation`: Operation or head stored in the e-node.
+- `args`: Extracted child expressions.
+
+# Keyword Arguments
+
+- `metadata=nothing`: Metadata preserved by the metadata analysis.
+- `exprhead=:call`: Expression head used when `T == Expr`.
+
+# Extension rule
+
+Define a method in the module that owns `T`, for example:
+
+```julia
+Metatheory.EGraphs.egraph_reconstruct_expression(
+    ::Type{MyTerm}, op, args; metadata=nothing, exprhead=:call,
+) = MyTerm(op, args)
+```
 """
 function egraph_reconstruct_expression(T::Type{Expr}, op, args; metadata = nothing, exprhead = :call)
   similarterm(Expr(:call, :_), op, args; metadata = metadata, exprhead = exprhead)

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -2,17 +2,43 @@
 # https://dl.acm.org/doi/10.1145/3434304
 
 
+"""
+    AbstractENode
+
+Abstract supertype for the nodes stored in an [`EGraph`](@ref).
+
+Concrete node types must be hashable and comparable. Tree nodes should provide
+the TermInterface methods `istree`, `operation`, `arguments`, `arity`, and
+`symtype`; literal nodes should report `istree(node) == false`.
+"""
 abstract type AbstractENode end
 
 import Metatheory: maybelock!
 
 const AnalysisData = NamedTuple{N,T} where {N,T<:Tuple}
+"""
+    EClassId
+
+Integer type used to identify e-classes inside an [`EGraph`](@ref).
+"""
 const EClassId = Int64
 const TermTypes = Dict{Tuple{Any,Int},Type}
 # TODO document bindings
 const Bindings = Base.ImmutableDict{Int,Tuple{Int,Int}}
 const DEFAULT_BUFFER_SIZE = 1048576
 
+"""
+    ENodeLiteral(value)
+
+Represent a literal value as an e-node.
+
+# Fields
+
+- `value`: Literal stored in the e-graph.
+
+Literal nodes are leaves: `TermInterface.istree(node)` is `false` and
+`operation(node)` returns `value`.
+"""
 struct ENodeLiteral <: AbstractENode
   value
   hash::Ref{UInt}
@@ -36,6 +62,23 @@ function Base.hash(t::ENodeLiteral, salt::UInt)
 end
 
 
+"""
+    ENodeTerm(exprhead, operation, symtype, class_ids)
+
+Represent a compound term whose children are e-class identifiers.
+
+# Arguments
+
+- `exprhead`: Expression head, such as `:call`.
+- `operation`: Function or operator represented by the node.
+- `symtype`: Symbolic result type.
+- `class_ids`: Vector of child [`EClassId`](@ref)s.
+
+# Fields
+
+- `exprhead`, `operation`, `symtype`, `args`: TermInterface data.
+- `hash`: Mutable hash cache; callers should not mutate it directly.
+"""
 mutable struct ENodeTerm <: AbstractENode
   exprhead::Union{Symbol,Nothing}
   operation::Any
@@ -72,6 +115,22 @@ end
 
 
 # parametrize metadata by M
+"""
+    EClass(g, id, nodes, parents, data)
+
+Store all equivalent e-nodes and analysis data for one e-class.
+
+# Fields
+
+- `g`: Owning [`EGraph`](@ref).
+- `id`: Canonical [`EClassId`](@ref).
+- `nodes`: E-nodes in this equivalence class.
+- `parents`: Parent e-nodes and their e-class identifiers.
+- `data`: Named tuple of analysis references.
+
+Use `EClass(g, id)` for an empty class associated with `g`; the shorter
+constructor initializes the node and parent collections.
+"""
 mutable struct EClass
   g # EGraph
   id::EClassId
@@ -144,14 +203,34 @@ function join_analysis_data!(g, dst::AnalysisData, src::AnalysisData)
 end
 
 # Thanks to Shashi Gowda
+"""
+    hasdata(eclass, analysis)
+
+Return whether `eclass` contains a value for an analysis identified by a symbol
+or analysis function.
+"""
 hasdata(a::EClass, analysis_name::Symbol) = hasproperty(a.data, analysis_name)
 hasdata(a::EClass, f::Function) = hasproperty(a.data, nameof(f))
+"""
+    getdata(eclass, analysis[, default])
+
+Return the value stored for `analysis` in `eclass`. When `default` is supplied,
+return it if no analysis value exists.
+"""
 getdata(a::EClass, analysis_name::Symbol) = getproperty(a.data, analysis_name)[]
 getdata(a::EClass, f::Function) = getproperty(a.data, nameof(f))[]
 getdata(a::EClass, analysis_ref::Union{Symbol,Function}, default) =
   hasdata(a, analysis_ref) ? getdata(a, analysis_ref) : default
 
 
+"""
+    setdata!(eclass, analysis, value)
+
+Store `value` as the analysis result for `analysis` in `eclass`.
+
+The value is wrapped in a mutable reference so that analysis updates do not
+replace the e-class named tuple.
+"""
 setdata!(a::EClass, f::Function, value) = setdata!(a, nameof(f), value)
 function setdata!(a::EClass, analysis_name::Symbol, value)
   if hasdata(a, analysis_name)
@@ -249,6 +328,12 @@ function addanalysis!(g::EGraph, analysis_name::Symbol)
   g.analyses[analysis_name] = analysis_name
 end
 
+"""
+    settermtype!(g, operation, arity, type)
+
+Register the symbolic result type used when reconstructing terms with
+`operation` and `arity` in `g`.
+"""
 function settermtype!(g::EGraph, f, ar, T)
   g.termtypes[(f, ar)] = T
 end
@@ -257,6 +342,12 @@ function settermtype!(g::EGraph, T)
   g.default_termtype = T
 end
 
+"""
+    gettermtype(g, operation, arity)
+
+Return the registered result type for a term, or `g.default_termtype` when no
+specific registration exists.
+"""
 function gettermtype(g::EGraph, f, ar)
   if haskey(g.termtypes, (f, ar))
     g.termtypes[(f, ar)]
@@ -304,6 +395,12 @@ function canonicalize!(g::EGraph, e::EClass)
   e.id = find(g, e.id)
 end
 
+"""
+    lookup(g, node) -> EClassId
+
+Return the e-class containing `node`, or `-1` when the canonical node is not in
+`g`.
+"""
 function lookup(g::EGraph, n::AbstractENode)::EClassId
   cc = canonicalize(g, n)
   haskey(g.memo, cc) ? find(g, g.memo[cc]) : -1
@@ -411,6 +508,12 @@ function Base.merge!(g::EGraph, a::EClassId, b::EClassId)::EClassId
   return to
 end
 
+"""
+    in_same_class(g, a, b) -> Bool
+
+Return whether e-class identifiers `a` and `b` denote the same equivalence
+class in `g`.
+"""
 function in_same_class(g::EGraph, a, b)
   find(g, a) == find(g, b)
 end

--- a/src/EGraphs/egraph.jl
+++ b/src/EGraphs/egraph.jl
@@ -354,12 +354,12 @@ its root e-class.
 - `expr`: A term accepted by the `TermInterface` traversal used by
   [`addexpr!`](@ref).
 
-# Keyword Arguments
+# Keywords
 
 - `keepmeta::Bool=false`: Preserve term metadata through the metadata analysis.
 - `needslock`, `buffer_size`: Forwarded to the empty-graph constructor.
 
-# Example
+# Examples
 
 ```julia
 g = EGraph(:(x + 1))
@@ -525,7 +525,7 @@ compound terms are hash-consed as [`ENodeTerm`](@ref) values.
 - `egraph`: Graph to mutate.
 - `expr`: Term accepted by the `TermInterface` interface.
 
-# Keyword Arguments
+# Keywords
 
 - `keepmeta::Bool=false`: Preserve metadata for later reconstruction.
 
@@ -729,7 +729,7 @@ produce; the default methods handle `Expr` values.
 - `operation`: Operation or head stored in the e-node.
 - `args`: Extracted child expressions.
 
-# Keyword Arguments
+# Keywords
 
 - `metadata=nothing`: Metadata preserved by the metadata analysis.
 - `exprhead=:call`: Expression head used when `T == Expr`.

--- a/src/EGraphs/intdisjointmap.jl
+++ b/src/EGraphs/intdisjointmap.jl
@@ -1,3 +1,12 @@
+"""
+    IntDisjointSet()
+
+Create an integer disjoint-set forest with union-by-size and path compression.
+
+The object is used by [`EGraph`](@ref) to store equivalence-class roots. Use
+`push!` to allocate identifiers, `union!` to merge sets, and `find` to retrieve
+canonical roots.
+"""
 struct IntDisjointSet
   parents::Vector{Int}
   normalized::Ref{Bool}
@@ -18,6 +27,11 @@ function find_root(x::IntDisjointSet, i::Int)::Int
   return i
 end
 
+"""
+    in_same_set(sets, a, b) -> Bool
+
+Return whether integer identifiers `a` and `b` belong to the same set.
+"""
 function in_same_set(x::IntDisjointSet, a::Int, b::Int)
   find_root(x, a) == find_root(x, b)
 end

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -1,12 +1,48 @@
+"""
+    SaturationGoal
+
+Abstract interface for stopping conditions passed to [`saturate!`](@ref).
+
+Concrete goals should implement `reached(g::EGraph, goal)` and return `true`
+when the requested condition has been met. A function goal is also accepted
+and is called with the current e-graph.
+
+# Example
+
+```julia
+struct MatchGoal <: SaturationGoal end
+Metatheory.EGraphs.reached(g::EGraph, ::MatchGoal) = length(g.classes) > 1
+
+params = SaturationParams(goal=MatchGoal())
+saturate!(EGraph(1), AbstractRule[], params)
+```
+"""
 abstract type SaturationGoal end
 
+"""
+    reached(g, goal) -> Bool
+
+Return whether `goal` has been reached in `g`.
+
+Extend this function for custom [`SaturationGoal`](@ref) types. Function goals
+are called with `g`; `nothing` and unimplemented goals return `false`.
+"""
 reached(g::EGraph, goal::Nothing) = false
 reached(g::EGraph, goal::SaturationGoal) = false
 reached(g::EGraph, goal::Function) = goal(g)
 
 """
-This goal is reached when the `exprs` list of expressions are in the 
-same equivalence class.
+    EqualityGoal(exprs, eclasses)
+
+Stop saturation when all identifiers in `eclasses` are in one equivalence
+class.
+
+# Fields
+
+- `exprs`: Expressions corresponding to the identifiers.
+- `ids`: E-class identifiers to compare.
+
+`exprs` and `eclasses` must have the same nonzero length.
 """
 struct EqualityGoal <: SaturationGoal
   exprs::Vector{Any}
@@ -45,21 +81,46 @@ function Base.show(io::IO, x::SaturationReport)
 end
 
 """
-Configurable Parameters for the equality saturation process.
+    SaturationParams(; kwargs...)
+
+Configure equality saturation.
+
+# Keyword Arguments
+
+- `timeout::Int=8`: Iteration or backend timeout limit.
+- `timelimit::UInt64=0`: Wall-clock limit in nanoseconds; `0` disables it.
+- `eclasslimit::Int=5000`: Maximum number of e-classes.
+- `enodelimit::Int=15000`: Maximum number of e-nodes.
+- `goal`: Optional [`SaturationGoal`](@ref) or function stopping condition.
+- `stopwhen`: Function requesting an early stop.
+- `scheduler`: Scheduler type used for rule search.
+- `schedulerparams`: Positional scheduler constructor arguments.
+- `threaded::Bool=false`: Enable threaded matching where supported.
+- `timer::Bool=true`: Record timing information in the report.
 """
-Base.@kwdef mutable struct SaturationParams
-  timeout::Int = 8
+mutable struct SaturationParams
+  timeout::Int
   "Timeout in nanoseconds"
-  timelimit::UInt64 = 0
+  timelimit::UInt64
   "Maximum number of eclasses allowed"
-  eclasslimit::Int = 5000
-  enodelimit::Int = 15000
-  goal::Union{Nothing,SaturationGoal,Function} = nothing
-  stopwhen::Function = () -> false
-  scheduler::Type{<:AbstractScheduler} = BackoffScheduler
-  schedulerparams::Tuple = ()
-  threaded::Bool = false
-  timer::Bool = true
+  eclasslimit::Int
+  enodelimit::Int
+  goal::Union{Nothing,SaturationGoal,Function}
+  stopwhen::Function
+  scheduler::Type{<:AbstractScheduler}
+  schedulerparams::Tuple
+  threaded::Bool
+  timer::Bool
+end
+
+function SaturationParams(; timeout::Int=8, timelimit::UInt64=UInt64(0),
+    eclasslimit::Int=5000, enodelimit::Int=15000,
+    goal::Union{Nothing,SaturationGoal,Function}=nothing,
+    stopwhen::Function=() -> false,
+    scheduler::Type{<:AbstractScheduler}=BackoffScheduler,
+    schedulerparams::Tuple=(), threaded::Bool=false, timer::Bool=true)
+  SaturationParams(timeout, timelimit, eclasslimit, enodelimit, goal, stopwhen,
+    scheduler, schedulerparams, threaded, timer)
 end
 
 # function cached_ids(g::EGraph, p::PatTerm)# ::Vector{Int64}
@@ -270,8 +331,18 @@ function eqsat_step!(
 end
 
 """
-Given an [`EGraph`](@ref) and a collection of rewrite rules,
-execute the equality saturation algorithm.
+    saturate!(g, theory, params=SaturationParams()) -> SaturationReport
+
+Apply `theory` to `g` until a stopping condition or resource limit is reached.
+
+# Arguments
+
+- `g`: E-graph to mutate.
+- `theory`: Vector of rewrite rules.
+- `params`: Saturation limits and scheduler configuration.
+
+The returned report records the stop reason, final e-graph, iteration count,
+and timing data.
 """
 function saturate!(g::EGraph, theory::Vector{<:AbstractRule}, params = SaturationParams())
   curr_iter = 0
@@ -322,6 +393,16 @@ function saturate!(g::EGraph, theory::Vector{<:AbstractRule}, params = Saturatio
   return report
 end
 
+"""
+    areequal(theory, exprs...; params=SaturationParams()) -> Bool
+
+Check whether `exprs` become equivalent after saturating an e-graph with
+`theory`.
+
+# Keyword Arguments
+
+- `params`: Saturation configuration.
+"""
 function areequal(theory::Vector, exprs...; params = SaturationParams())
   g = EGraph(exprs[1])
   areequal(g, theory, exprs...; params = params)
@@ -346,10 +427,20 @@ function areequal(g::EGraph, t::Vector{<:AbstractRule}, exprs...; params = Satur
   return reached(g, goal)
 end
 
+"""
+    @areequal theory exprs...
+
+Macro form of [`areequal`](@ref).
+"""
 macro areequal(theory, exprs...)
   esc(:(areequal($theory, $exprs...)))
 end
 
+"""
+    @areequalg G theory exprs...
+
+Check equivalence of `exprs` in existing e-graph `G` using `theory`.
+"""
 macro areequalg(G, theory, exprs...)
   esc(:(areequal($G, $theory, $exprs...)))
 end

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -7,7 +7,7 @@ Concrete goals should implement `reached(g::EGraph, goal)` and return `true`
 when the requested condition has been met. A function goal is also accepted
 and is called with the current e-graph.
 
-# Example
+# Examples
 
 ```julia
 struct MatchGoal <: SaturationGoal end
@@ -32,9 +32,9 @@ reached(g::EGraph, goal::SaturationGoal) = false
 reached(g::EGraph, goal::Function) = goal(g)
 
 """
-    EqualityGoal(exprs, eclasses)
+    EqualityGoal(exprs, ids)
 
-Stop saturation when all identifiers in `eclasses` are in one equivalence
+Stop saturation when all identifiers in `ids` are in one equivalence
 class.
 
 # Fields
@@ -42,7 +42,7 @@ class.
 - `exprs`: Expressions corresponding to the identifiers.
 - `ids`: E-class identifiers to compare.
 
-`exprs` and `eclasses` must have the same nonzero length.
+`exprs` and `ids` must have the same nonzero length.
 """
 struct EqualityGoal <: SaturationGoal
   exprs::Vector{Any}
@@ -85,7 +85,7 @@ end
 
 Configure equality saturation.
 
-# Keyword Arguments
+# Keywords
 
 - `timeout::Int=8`: Iteration or backend timeout limit.
 - `timelimit::UInt64=0`: Wall-clock limit in nanoseconds; `0` disables it.
@@ -98,29 +98,19 @@ Configure equality saturation.
 - `threaded::Bool=false`: Enable threaded matching where supported.
 - `timer::Bool=true`: Record timing information in the report.
 """
-mutable struct SaturationParams
-  timeout::Int
+Base.@kwdef mutable struct SaturationParams
+  timeout::Int = 8
   "Timeout in nanoseconds"
-  timelimit::UInt64
+  timelimit::UInt64 = 0
   "Maximum number of eclasses allowed"
-  eclasslimit::Int
-  enodelimit::Int
-  goal::Union{Nothing,SaturationGoal,Function}
-  stopwhen::Function
-  scheduler::Type{<:AbstractScheduler}
-  schedulerparams::Tuple
-  threaded::Bool
-  timer::Bool
-end
-
-function SaturationParams(; timeout::Int=8, timelimit::UInt64=UInt64(0),
-    eclasslimit::Int=5000, enodelimit::Int=15000,
-    goal::Union{Nothing,SaturationGoal,Function}=nothing,
-    stopwhen::Function=() -> false,
-    scheduler::Type{<:AbstractScheduler}=BackoffScheduler,
-    schedulerparams::Tuple=(), threaded::Bool=false, timer::Bool=true)
-  SaturationParams(timeout, timelimit, eclasslimit, enodelimit, goal, stopwhen,
-    scheduler, schedulerparams, threaded, timer)
+  eclasslimit::Int = 5000
+  enodelimit::Int = 15000
+  goal::Union{Nothing,SaturationGoal,Function} = nothing
+  stopwhen::Function = () -> false
+  scheduler::Type{<:AbstractScheduler} = BackoffScheduler
+  schedulerparams::Tuple = ()
+  threaded::Bool = false
+  timer::Bool = true
 end
 
 # function cached_ids(g::EGraph, p::PatTerm)# ::Vector{Int64}
@@ -403,7 +393,7 @@ end
 Check whether `exprs` become equivalent after saturating an e-graph with
 `theory`.
 
-# Keyword Arguments
+# Keywords
 
 - `params`: Saturation configuration.
 """

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -175,21 +175,25 @@ function eqsat_search!(
 
   @debug "SEARCHING"
   for (rule_idx, rule) in enumerate(theory)
-    @timeit report.to string(rule_idx) begin
-      prev_matches = n_matches
-      # don't apply banned rules
-      if !cansearch(scheduler, rule)
-        @debug "$rule is banned"
-        continue
-      end
-      ids = cached_ids(g, rule.left)
-      rule isa BidirRule && (ids = ids ∪ cached_ids(g, rule.right))
-      for i in ids
-        n_matches += rule.ematcher!(g, rule_idx, i)
-      end
-      n_matches - prev_matches > 0 && @debug "Rule $rule_idx: $rule produced $(n_matches - prev_matches) matches"
-      inform!(scheduler, rule, n_matches)
-    end
+    timeit(
+      () -> begin
+        prev_matches = n_matches
+        # don't apply banned rules
+        if cansearch(scheduler, rule)
+          ids = cached_ids(g, rule.left)
+          rule isa BidirRule && (ids = ids ∪ cached_ids(g, rule.right))
+          for i in ids
+            n_matches += rule.ematcher!(g, rule_idx, i)
+          end
+          n_matches - prev_matches > 0 && @debug "Rule $rule_idx: $rule produced $(n_matches - prev_matches) matches"
+          inform!(scheduler, rule, n_matches)
+        else
+          @debug "$rule is banned"
+        end
+      end,
+      report.to,
+      string(rule_idx),
+    )
   end
 
 
@@ -316,14 +320,14 @@ function eqsat_step!(
 
   setiter!(scheduler, curr_iter)
 
-  @timeit report.to "Search" eqsat_search!(g, theory, scheduler, report)
+  timeit(() -> eqsat_search!(g, theory, scheduler, report), report.to, "Search")
 
-  @timeit report.to "Apply" eqsat_apply!(g, theory, report, params)
+  timeit(() -> eqsat_apply!(g, theory, report, params), report.to, "Apply")
 
   if report.reason === nothing && cansaturate(scheduler) && isempty(g.dirty)
     report.reason = :saturated
   end
-  @timeit report.to "Rebuild" rebuild!(g)
+  timeit(() -> rebuild!(g), report.to, "Rebuild")
 
   @debug smallest_expr = extract!(g, astsize)
 

--- a/src/EGraphs/saturation.jl
+++ b/src/EGraphs/saturation.jl
@@ -1,7 +1,7 @@
 """
     SaturationGoal
 
-Abstract interface for stopping conditions passed to [`saturate!`](@ref).
+Abstract interface for stopping conditions passed to [`saturate!`](@ref Metatheory.EGraphs.saturate!).
 
 Concrete goals should implement `reached(g::EGraph, goal)` and return `true`
 when the requested condition has been met. A function goal is also accepted
@@ -24,7 +24,7 @@ abstract type SaturationGoal end
 
 Return whether `goal` has been reached in `g`.
 
-Extend this function for custom [`SaturationGoal`](@ref) types. Function goals
+Extend this function for custom [`SaturationGoal`](@ref Metatheory.EGraphs.SaturationGoal) types. Function goals
 are called with `g`; `nothing` and unimplemented goals return `false`.
 """
 reached(g::EGraph, goal::Nothing) = false
@@ -91,7 +91,7 @@ Configure equality saturation.
 - `timelimit::UInt64=0`: Wall-clock limit in nanoseconds; `0` disables it.
 - `eclasslimit::Int=5000`: Maximum number of e-classes.
 - `enodelimit::Int=15000`: Maximum number of e-nodes.
-- `goal`: Optional [`SaturationGoal`](@ref) or function stopping condition.
+- `goal`: Optional [`SaturationGoal`](@ref Metatheory.EGraphs.SaturationGoal) or function stopping condition.
 - `stopwhen`: Function requesting an early stop.
 - `scheduler`: Scheduler type used for rule search.
 - `schedulerparams`: Positional scheduler constructor arguments.
@@ -434,7 +434,7 @@ end
 """
     @areequal theory exprs...
 
-Macro form of [`areequal`](@ref).
+Macro form of [`areequal`](@ref Metatheory.EGraphs.areequal).
 """
 macro areequal(theory, exprs...)
   esc(:(areequal($theory, $exprs...)))

--- a/src/Library.jl
+++ b/src/Library.jl
@@ -4,22 +4,42 @@
 
 include("docstrings.jl")
 
+"""
+    Library
+
+Macros that generate common algebraic rewrite theories.
+"""
 module Library
 
 using Metatheory.Patterns
 using Metatheory.Rules
 
 
+"""
+    @commutativity op
+
+Create a rule rewriting `op(a, b)` to `op(b, a)`.
+"""
 macro commutativity(op)
   RewriteRule(PatTerm(:call, op, [PatVar(:a), PatVar(:b)]), PatTerm(:call, op, [PatVar(:b), PatVar(:a)]))
 end
 
+"""
+    @right_associative op
+
+Create a rule rewriting `op(a, op(b, c))` to `op(op(a, b), c)`.
+"""
 macro right_associative(op)
   RewriteRule(
     PatTerm(:call, op, [PatVar(:a), PatTerm(:call, op, [PatVar(:b), PatVar(:c)])]),
     PatTerm(:call, op, [PatTerm(:call, op, [PatVar(:a), PatVar(:b)]), PatVar(:c)]),
   )
 end
+"""
+    @left_associative op
+
+Create a rule rewriting `op(op(a, b), c)` to `op(a, op(b, c))`.
+"""
 macro left_associative(op)
   RewriteRule(
     PatTerm(:call, op, [PatTerm(:call, op, [PatVar(:a), PatVar(:b)]), PatVar(:c)]),
@@ -28,34 +48,70 @@ macro left_associative(op)
 end
 
 
+"""
+    @identity_left op id
+
+Create a rule rewriting `op(id, a)` to `a`.
+"""
 macro identity_left(op, id)
   RewriteRule(PatTerm(:call, op, [id, PatVar(:a)]), PatVar(:a))
 end
 
+"""
+    @identity_right op id
+
+Create a rule rewriting `op(a, id)` to `a`.
+"""
 macro identity_right(op, id)
   RewriteRule(PatTerm(:call, op, [PatVar(:a), id]), PatVar(:a))
 end
 
+"""
+    @inverse_left op id invop
+
+Create a rule rewriting `op(invop(a), a)` to `id`.
+"""
 macro inverse_left(op, id, invop)
   RewriteRule(PatTerm(:call, op, [PatTerm(:call, invop, [PatVar(:a)]), PatVar(:a)]), id)
 end
+"""
+    @inverse_right op id invop
+
+Create a rule rewriting `op(a, invop(a))` to `id`.
+"""
 macro inverse_right(op, id, invop)
   RewriteRule(PatTerm(:call, op, [PatVar(:a), PatTerm(:call, invop, [PatVar(:a)])]), id)
 end
 
 
+"""
+    @associativity op
+
+Return both left- and right-associativity rules for `op`.
+"""
 macro associativity(op)
   esc(quote
     [(@left_associative $op), (@right_associative $op)]
   end)
 end
 
+"""
+    @monoid op id
+
+Return associativity and identity rules for a monoid operation.
+"""
 macro monoid(op, id)
   esc(quote
     [(@left_associative($op)), (@right_associative($op)), (@identity_left($op, $id)), (@identity_right($op, $id))]
   end)
 end
 
+"""
+    @commutative_monoid op id
+
+Return commutativity, associativity, and identity rules for a commutative
+monoid operation.
+"""
 macro commutative_monoid(op, id)
   esc(quote
     [(@commutativity $op), (@left_associative $op), (@right_associative $op), (@identity_left $op $id)]
@@ -66,6 +122,11 @@ end
 # The definition of a group does not require that a ⋅ b = b ⋅ a
 # for all elements a and b in G. If this additional condition holds,
 # then the operation is said to be commutative, and the group is called an abelian group.
+"""
+    @commutative_group op id invop
+
+Return a commutative-monoid theory together with an inverse rule.
+"""
 macro commutative_group(op, id, invop)
   # @assert Base.isbinaryoperator(op)
   # @assert Base.isunaryoperator(invop)
@@ -74,6 +135,11 @@ macro commutative_group(op, id, invop)
   end)
 end
 
+"""
+    @distrib outop inop
+
+Return left- and right-distributivity rules for `outop` over `inop`.
+"""
 macro distrib(outop, inop)
   esc(quote
     [(@distrib_left $outop $inop), (@distrib_right $outop $inop)]
@@ -84,12 +150,22 @@ end
 
 # distributivity of two operations
 # example: `@distrib (⋅) (⊕)`
+"""
+    @distrib_left outop inop
+
+Create the left-distributivity rule for `outop` over `inop`.
+"""
 macro distrib_left(outop, inop)
   esc(quote
     @rule a b c ($outop)(a, $(inop)(b, c)) == $(inop)($(outop)(a, b), $(outop)(a, c))
   end)
 end
 
+"""
+    @distrib_right outop inop
+
+Create the right-distributivity rule for `outop` over `inop`.
+"""
 macro distrib_right(outop, inop)
   esc(quote
     @rule a b c ($outop)($(inop)(a, b), c) == $(inop)($(outop)(a, c), $(outop)(b, c))

--- a/src/Library.jl
+++ b/src/Library.jl
@@ -11,8 +11,9 @@ Macros that generate common algebraic rewrite theories.
 """
 module Library
 
-using Metatheory.Patterns
-using Metatheory.Rules
+import Metatheory.Patterns: PatTerm, PatVar
+import Metatheory.Rules: RewriteRule
+import Metatheory.Syntax: @rule
 
 
 """

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -3,10 +3,10 @@
 
 Term-rewriting and equality-saturation tools for symbolic expressions.
 
-The public interface is organized into [`Patterns`](@ref), [`Rules`](@ref),
-[`Rewriters`](@ref), and [`EGraphs`](@ref). Construct patterns and rules with
-the syntax macros, then use [`rewrite`](@ref) for ordinary rewriting or
-[`EGraphs.saturate!`](@ref) for equality saturation.
+The public interface is organized into [`Patterns`](@ref Metatheory.Patterns), [`Rules`](@ref Metatheory.Rules),
+[`Rewriters`](@ref Metatheory.Rewriters), and [`EGraphs`](@ref Metatheory.EGraphs). Construct patterns and rules with
+the syntax macros, then use [`rewrite`](@ref Metatheory.rewrite) for ordinary rewriting or
+[`EGraphs.saturate!`](@ref Metatheory.EGraphs.saturate!) for equality saturation.
 """
 module Metatheory
 
@@ -68,7 +68,7 @@ Repeatedly apply `theory` to an expression using tree traversal.
   for pre-order rewriting.
 
 The function preserves the input when a rule does not apply. Use
-[`EGraphs.saturate!`](@ref) when all equivalent forms should be retained.
+[`EGraphs.saturate!`](@ref Metatheory.EGraphs.saturate!) when all equivalent forms should be retained.
 """
 function rewrite(expr, theory; order = :outer)
   if order == :inner

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -10,11 +10,11 @@ the syntax macros, then use [`rewrite`](@ref) for ordinary rewriting or
 """
 module Metatheory
 
-using DataStructures
-
-using Base.Meta
-using Reexport
-using TermInterface
+import DataStructures
+import Base.Meta: isexpr
+import Reexport: @reexport
+import TermInterface
+import TermInterface: arguments, arity, exprhead, istree, metadata, operation, similarterm, symtype
 using PrecompileTools: @compile_workload, @setup_workload
 
 @inline alwaystrue(x) = true
@@ -49,7 +49,7 @@ include("Library.jl")
 export Library
 
 include("Rewriters.jl")
-using .Rewriters
+import .Rewriters: Chain, Fixpoint, Postwalk, Prewalk
 export Rewriters
 
 """

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -1,3 +1,13 @@
+"""
+    Metatheory
+
+Term-rewriting and equality-saturation tools for symbolic expressions.
+
+The public interface is organized into [`Patterns`](@ref), [`Rules`](@ref),
+[`Rewriters`](@ref), and [`EGraphs`](@ref). Construct patterns and rules with
+the syntax macros, then use [`rewrite`](@ref) for ordinary rewriting or
+[`EGraphs.saturate!`](@ref) for equality saturation.
+"""
 module Metatheory
 
 using DataStructures
@@ -32,6 +42,7 @@ include("Rules.jl")
 include("Syntax.jl")
 @reexport using .Syntax
 include("EGraphs/EGraphs.jl")
+import .EGraphs: in_same_set
 @reexport using .EGraphs
 
 include("Library.jl")
@@ -41,6 +52,24 @@ include("Rewriters.jl")
 using .Rewriters
 export Rewriters
 
+"""
+    rewrite(expr, theory; order=:outer)
+
+Repeatedly apply `theory` to an expression using tree traversal.
+
+# Arguments
+
+- `expr`: Expression or TermInterface-compatible tree to rewrite.
+- `theory`: Iterable of callable rewrite rules.
+
+# Keyword Arguments
+
+- `order::Symbol=:outer`: Use `:outer` for post-order rewriting or `:inner`
+  for pre-order rewriting.
+
+The function preserves the input when a rule does not apply. Use
+[`EGraphs.saturate!`](@ref) when all equivalent forms should be retained.
+"""
 function rewrite(expr, theory; order = :outer)
   if order == :inner
     Fixpoint(Prewalk(Fixpoint(Chain(theory))))(expr)

--- a/src/Metatheory.jl
+++ b/src/Metatheory.jl
@@ -62,7 +62,7 @@ Repeatedly apply `theory` to an expression using tree traversal.
 - `expr`: Expression or TermInterface-compatible tree to rewrite.
 - `theory`: Iterable of callable rewrite rules.
 
-# Keyword Arguments
+# Keywords
 
 - `order::Symbol=:outer`: Use `:outer` for post-order rewriting or `:inner`
   for pre-order rewriting.

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -76,7 +76,7 @@ The short constructor `PatVar(:x)` creates an unrestricted variable. In user
 syntax, the equivalent pattern is `~x`; a type or predicate can be written as
 `~x::Number` or `~x::is_valid`.
 
-# Example
+# Examples
 
 ```julia
 r = @rule sin(~x::Number) --> cos(~x)
@@ -117,7 +117,7 @@ The short constructor `PatSegment(:xs)` creates an unrestricted segment. In
 user syntax, the equivalent pattern is `~xs...`. A segment predicate receives
 the vector of matched terms and must return a Boolean.
 
-# Example
+# Examples
 
 ```julia
 r = @rule f(~xs...) --> g(~xs...)

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -19,7 +19,7 @@ matchers.
 
 Concrete patterns must expose the TermInterface tree methods when they represent
 compound terms. Pattern variables and segment patterns are the two built-in
-binding forms. Users normally construct them through [`@rule`](@ref) rather
+binding forms. Users normally construct them through [`@rule`](@ref Metatheory.Syntax.@rule) rather
 than calling these constructors directly.
 """
 abstract type AbstractPat end
@@ -63,7 +63,7 @@ Represent a pattern variable that matches exactly one subterm.
 
 - `name::Symbol`: Name used when displaying the pattern.
 - `debrujin_index::Int`: Matcher binding index; `-1` means it has not yet been
-  assigned by [`setdebrujin!`](@ref).
+  assigned by [`setdebrujin!`](@ref Metatheory.Patterns.setdebrujin!).
 - `predicate`: Function or type restriction applied to each candidate match.
 
 # Fields
@@ -110,7 +110,7 @@ Represent a pattern variable that matches zero or more consecutive arguments.
 
 - `name::Symbol`: Name used when displaying the pattern.
 - `debrujin_index::Int`: Matcher binding index, assigned by
-  [`setdebrujin!`](@ref).
+  [`setdebrujin!`](@ref Metatheory.Patterns.setdebrujin!).
 - `predicate`: Function applied to the complete vector of matched arguments.
 
 The short constructor `PatSegment(:xs)` creates an unrestricted segment. In
@@ -148,7 +148,7 @@ patterns.
 - `args::Vector`: Child patterns, matched in order.
 
 A `PatTerm` matches only a term with the same expression head, operation, and
-arity. It is normally produced by [`@rule`](@ref); direct construction is
+arity. It is normally produced by [`@rule`](@ref Metatheory.Syntax.@rule); direct construction is
 useful for implementing custom matchers.
 """
 struct PatTerm <: AbstractPat

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -1,3 +1,9 @@
+"""
+    Patterns
+
+Pattern types and utilities used by Metatheory's matching and rewriting
+backends.
+"""
 module Patterns
 
 using Metatheory: binarize, cleanast, alwaystrue
@@ -11,6 +17,15 @@ Abstract type representing a pattern used in all the various pattern matching ba
 abstract type AbstractPat end
 
 
+"""
+    UnsupportedPatternException(pattern)
+
+Exception thrown when a backend cannot match `pattern`.
+
+# Fields
+
+- `p`: Unsupported [`AbstractPat`](@ref).
+"""
 struct UnsupportedPatternException <: Exception
   p::AbstractPat
 end
@@ -113,6 +128,20 @@ patvars(p) = unique!(patvars(p, Symbol[]))
 # ================== DEBRUJIN INDEXING =========
 # ==============================================
 
+"""
+    setdebrujin!(pattern, variables)
+
+Assign de Bruijn indices to pattern variables in `pattern`.
+
+# Arguments
+
+- `pattern`: Pattern to mutate.
+- `variables`: Ordered collection of variable names; each pattern variable's
+  index is its position in this collection.
+
+The operation mutates `PatVar` and `PatSegment` instances and recursively visits
+`PatTerm` arguments. Literal values are ignored.
+"""
 function setdebrujin!(p::Union{PatVar,PatSegment}, pvars)
   p.idx = findfirst((==)(p.name), pvars)
 end

--- a/src/Patterns.jl
+++ b/src/Patterns.jl
@@ -6,13 +6,21 @@ backends.
 """
 module Patterns
 
-using Metatheory: binarize, cleanast, alwaystrue
-using AutoHashEquals
-using TermInterface
+import Metatheory: alwaystrue
+import TermInterface
+import TermInterface: arguments, exprhead, operation, similarterm
 
 
 """
-Abstract type representing a pattern used in all the various pattern matching backends. 
+    AbstractPat
+
+Abstract supertype for patterns consumed by Metatheory's classical and e-graph
+matchers.
+
+Concrete patterns must expose the TermInterface tree methods when they represent
+compound terms. Pattern variables and segment patterns are the two built-in
+binding forms. Users normally construct them through [`@rule`](@ref) rather
+than calling these constructors directly.
 """
 abstract type AbstractPat end
 
@@ -36,8 +44,11 @@ Base.showerror(io::IO, e::UnsupportedPatternException) = print(io, "Pattern ", e
 Base.:(==)(a::AbstractPat, b::AbstractPat) = false
 TermInterface.arity(p::AbstractPat) = 0
 """
-A ground pattern contains no pattern variables and 
-only literal values to match.
+    isground(pattern) -> Bool
+
+Return `true` when `pattern` contains no [`PatVar`](@ref) or
+[`PatSegment`](@ref) bindings and can therefore be looked up as a literal
+term. Non-pattern values are ground by definition.
 """
 isground(p::AbstractPat) = false
 isground(x) = true # literals
@@ -46,8 +57,31 @@ isground(x) = true # literals
 """
     PatVar{P}(name, debrujin_index, predicate::P)
 
-Pattern variables will first match on one subterm
-and instantiate the substitution to that subterm.
+Represent a pattern variable that matches exactly one subterm.
+
+# Arguments
+
+- `name::Symbol`: Name used when displaying the pattern.
+- `debrujin_index::Int`: Matcher binding index; `-1` means it has not yet been
+  assigned by [`setdebrujin!`](@ref).
+- `predicate`: Function or type restriction applied to each candidate match.
+
+# Fields
+
+- `name`, `idx`, `predicate`, `predicate_code`: Mutable matcher state. The
+  `idx` and `predicate_code` fields are compiler bookkeeping and should be
+  left to the rule constructors.
+
+The short constructor `PatVar(:x)` creates an unrestricted variable. In user
+syntax, the equivalent pattern is `~x`; a type or predicate can be written as
+`~x::Number` or `~x::is_valid`.
+
+# Example
+
+```julia
+r = @rule sin(~x::Number) --> cos(~x)
+r(:(sin(1)))
+```
 
 Matcher pattern may contain pattern variables with attached predicates,
 where `predicate` is a function that takes a matched expression and returns a
@@ -68,11 +102,27 @@ PatVar(var) = PatVar(var, -1, alwaystrue, nothing)
 PatVar(var, i) = PatVar(var, i, alwaystrue, nothing)
 
 """
-If you want to match a variable number of subexpressions at once, you will need
-a **segment pattern**. 
-A segment pattern represents a vector of subexpressions matched. 
-You can attach a predicate `g` to a segment variable. In the case of segment variables `g` gets a vector of 0 or more 
-expressions and must return a boolean value. 
+    PatSegment{P}(name, debrujin_index, predicate::P)
+
+Represent a pattern variable that matches zero or more consecutive arguments.
+
+# Arguments
+
+- `name::Symbol`: Name used when displaying the pattern.
+- `debrujin_index::Int`: Matcher binding index, assigned by
+  [`setdebrujin!`](@ref).
+- `predicate`: Function applied to the complete vector of matched arguments.
+
+The short constructor `PatSegment(:xs)` creates an unrestricted segment. In
+user syntax, the equivalent pattern is `~xs...`. A segment predicate receives
+the vector of matched terms and must return a Boolean.
+
+# Example
+
+```julia
+r = @rule f(~xs...) --> g(~xs...)
+r(:(f(a, b)))
+```
 """
 mutable struct PatSegment{P} <: AbstractPat
   name::Symbol
@@ -86,9 +136,20 @@ PatSegment(v, i) = PatSegment(v, i, alwaystrue, nothing)
 
 
 """
-Term patterns will match
-on terms of the same `arity` and with the same 
-function symbol `operation` and expression head `exprhead`.
+    PatTerm(exprhead, operation, args)
+
+Represent a compound pattern with a term-interface head, operation, and child
+patterns.
+
+# Arguments
+
+- `exprhead`: Expression head, usually `:call`.
+- `operation`: Function, operator, or literal operation to match.
+- `args::Vector`: Child patterns, matched in order.
+
+A `PatTerm` matches only a term with the same expression head, operation, and
+arity. It is normally produced by [`@rule`](@ref); direct construction is
+useful for implementing custom matchers.
 """
 struct PatTerm <: AbstractPat
   exprhead::Any
@@ -115,7 +176,10 @@ isground(p::PatTerm) = all(isground, p.args)
 # ==============================================
 
 """
-Collects pattern variables appearing in a pattern into a vector of symbols
+    patvars(pattern) -> Vector{Symbol}
+
+Collect the unique pattern-variable names appearing in `pattern`, in traversal
+order. Literal values do not contribute names.
 """
 patvars(p::PatVar, s) = push!(s, p.name)
 patvars(p::PatSegment, s) = push!(s, p.name)

--- a/src/Rewriters.jl
+++ b/src/Rewriters.jl
@@ -30,7 +30,7 @@ rewriters.
 
 """
 module Rewriters
-import TermInterface: arguments, exprhead, istree, operation, similarterm, unsorted_arguments
+import TermInterface: arguments, exprhead, istree, node_count, operation, similarterm, unsorted_arguments
 import Metatheory: @timer
 
 export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
@@ -285,6 +285,8 @@ function (p::Walk{ord,C,F,true})(x) where {ord,C,F}
       end
       args = map((t, a) -> passthrough(t isa Task ? fetch(t) : t, a), _args, arguments(x))
       t = p.similarterm(x, operation(x), args; exprhead = exprhead(x))
+    else
+      t = x
     end
     return ord === :post ? p.rw(t) : t
   else

--- a/src/Rewriters.jl
+++ b/src/Rewriters.jl
@@ -215,7 +215,7 @@ import Base.Threads
 Construct a bottom-up TermInterface tree traversal that applies `rw` after
 rewriting children.
 
-# Keyword Arguments
+# Keywords
 
 - `threaded`: Spawn tasks for sufficiently large child subtrees.
 - `thread_cutoff`: Minimum `node_count` for spawning a child task.
@@ -231,7 +231,7 @@ end
 Construct a top-down TermInterface tree traversal that applies `rw` before
 rewriting children.
 
-# Keyword Arguments
+# Keywords
 
 - `threaded`: Spawn tasks for sufficiently large child subtrees.
 - `thread_cutoff`: Minimum `node_count` for spawning a child task.

--- a/src/Rewriters.jl
+++ b/src/Rewriters.jl
@@ -39,6 +39,11 @@ export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, Pa
 const repr_cache = IdDict()
 cached_repr(x) = Base.get!(() -> repr(x), repr_cache, x)
 
+"""
+    Empty()
+
+A rewriter that always returns `nothing`.
+"""
 struct Empty end
 
 (rw::Empty)(x) = nothing
@@ -46,6 +51,18 @@ struct Empty end
 instrument(x, f) = f(x)
 instrument(x::Empty, f) = x
 
+"""
+    IfElse(cond, yes, no)
+
+Apply `yes` when `cond(x)` is true and `no` otherwise. Each branch is a
+callable rewriter returning a value or `nothing`.
+
+# Fields
+
+- `cond`: Predicate callable on the input.
+- `yes`: True branch rewriter.
+- `no`: False branch rewriter.
+"""
 struct IfElse{F,A,B}
   cond::F
   yes::A
@@ -58,8 +75,19 @@ function (rw::IfElse)(x)
   rw.cond(x) ? rw.yes(x) : rw.no(x)
 end
 
+"""
+    If(cond, rw)
+
+Construct an [`IfElse`](@ref) with [`Empty`](@ref) as its false branch.
+"""
 If(f, x) = IfElse(f, x, Empty())
 
+"""
+    Chain(rws)
+
+Apply an iterable of rewriters in order, retaining the current value when a
+rewriter returns `nothing`.
+"""
 struct Chain
   rws
 end
@@ -76,6 +104,12 @@ end
 
 instrument(c::Chain, f) = Chain(map(x -> instrument(x, f), c.rws))
 
+"""
+    RestartedChain(rws)
+
+Apply rewriters in order and restart at the first rewriter after a successful
+rewrite.
+"""
 struct RestartedChain{Cs}
   rws::Cs
 end
@@ -107,6 +141,11 @@ end
 end
 
 
+"""
+    Fixpoint(rw)
+
+Apply `rw` until it returns `nothing` or an equal value.
+"""
 struct Fixpoint{C}
   rw::C
 end
@@ -170,14 +209,43 @@ end
 
 using .Threads
 
+"""
+    Postwalk(rw; threaded=false, thread_cutoff=100, similarterm=similarterm)
+
+Construct a bottom-up TermInterface tree traversal that applies `rw` after
+rewriting children.
+
+# Keyword Arguments
+
+- `threaded`: Spawn tasks for sufficiently large child subtrees.
+- `thread_cutoff`: Minimum `node_count` for spawning a child task.
+- `similarterm`: TermInterface reconstruction function.
+"""
 function Postwalk(rw; threaded::Bool = false, thread_cutoff = 100, similarterm = similarterm)
   Walk{:post,typeof(rw),typeof(similarterm),threaded}(rw, thread_cutoff, similarterm)
 end
 
+"""
+    Prewalk(rw; threaded=false, thread_cutoff=100, similarterm=similarterm)
+
+Construct a top-down TermInterface tree traversal that applies `rw` before
+rewriting children.
+
+# Keyword Arguments
+
+- `threaded`: Spawn tasks for sufficiently large child subtrees.
+- `thread_cutoff`: Minimum `node_count` for spawning a child task.
+- `similarterm`: TermInterface reconstruction function.
+"""
 function Prewalk(rw; threaded::Bool = false, thread_cutoff = 100, similarterm = similarterm)
   Walk{:pre,typeof(rw),typeof(similarterm),threaded}(rw, thread_cutoff, similarterm)
 end
 
+"""
+    PassThrough(rw)
+
+Wrap `rw` so that a `nothing` result is replaced with the original input.
+"""
 struct PassThrough{C}
   rw::C
 end

--- a/src/Rewriters.jl
+++ b/src/Rewriters.jl
@@ -13,7 +13,7 @@ rewriters.
 - `RestartedChain(itr)` like `Chain(itr)` but restarts from the first rewriter once on the
    first successful application of one of the chained rewriters.
 - `IfElse(cond, rw1, rw2)` runs the `cond` function on the input, applies `rw1` if cond
-   returns true, `rw2` if it retuns false
+   returns true, `rw2` if it returns false
 - `If(cond, rw)` is the same as `IfElse(cond, rw, Empty())`
 - `Prewalk(rw; threaded=false, thread_cutoff=100)` returns a rewriter which does a pre-order
    traversal of a given expression and applies the rewriter `rw`. Note that if
@@ -30,8 +30,8 @@ rewriters.
 
 """
 module Rewriters
-using TermInterface
-using Metatheory: @timer
+import TermInterface: arguments, exprhead, istree, operation, similarterm, unsorted_arguments
+import Metatheory: @timer
 
 export Empty, IfElse, If, Chain, RestartedChain, Fixpoint, Postwalk, Prewalk, PassThrough
 
@@ -128,7 +128,7 @@ end
 
 @generated function (rw::RestartedChain{<:NTuple{N,Any}})(x) where {N}
   quote
-    Base.@nexprs $N i -> begin
+    for i in 1:($N)
       let f = rw.rws[i]
         y = @timer cached_repr(repr(f)) f(x)
         if y !== nothing
@@ -207,7 +207,7 @@ function instrument(x::Walk{ord,C,F,threaded}, f) where {ord,C,F,threaded}
   Walk{ord,typeof(irw),typeof(x.similarterm),threaded}(irw, x.thread_cutoff, x.similarterm)
 end
 
-using .Threads
+import Base.Threads
 
 """
     Postwalk(rw; threaded=false, thread_cutoff=100, similarterm=similarterm)

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -26,7 +26,7 @@ expects the rule to expose the pattern information required by its matcher.
 
 Implement `(::MyRule)(term)`, return `nothing` for a non-match, and define
 equality if rules are stored in dictionaries or scheduler state. Subtype
-[`SymbolicRule`](@ref) when the rule has symbolic left and right patterns.
+[`SymbolicRule`](@ref Metatheory.Rules.SymbolicRule) when the rule has symbolic left and right patterns.
 
 # Example
 
@@ -43,7 +43,7 @@ Base.:(==)(a::AbstractRule, b::AbstractRule) = false
     SymbolicRule <: AbstractRule
 
 Abstract supertype for rules whose left and right sides are symbolic patterns.
-Subtypes store pattern data and are normally constructed by [`@rule`](@ref).
+Subtypes store pattern data and are normally constructed by [`@rule`](@ref Metatheory.Syntax.@rule).
 """
 abstract type SymbolicRule <: AbstractRule end
 
@@ -229,7 +229,7 @@ classical rewriting), and one positional value per pattern variable.
 - `rhs_code`, `matcher`, `patvars`, `ematcher!`: Display and compiled matcher
   state.
 
-Use the [`@rule`](@ref) `=>` form unless constructing a custom rule backend.
+Use the [`@rule`](@ref Metatheory.Syntax.@rule) `=>` form unless constructing a custom rule backend.
 
 Dynamic rule
 ```julia

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -1,3 +1,9 @@
+"""
+    Rules
+
+Rule types used by Metatheory's pattern matcher and equality-saturation
+engine. Rules are callable and return a rewritten value or `nothing`.
+"""
 module Rules
 
 using TermInterface
@@ -9,12 +15,31 @@ using Metatheory: cleanast, binarize, matcher, instantiate
 
 const EMPTY_DICT = Base.ImmutableDict{Int,Any}()
 
+"""
+    AbstractRule
+
+Abstract supertype for all Metatheory rules.
+
+Concrete subtypes must be callable on a term. A rule returns the rewritten term
+when it matches and `nothing` otherwise.
+"""
 abstract type AbstractRule end
 # Must override
 Base.:(==)(a::AbstractRule, b::AbstractRule) = false
 
+"""
+    SymbolicRule <: AbstractRule
+
+Abstract supertype for rules whose left and right sides are symbolic patterns.
+"""
 abstract type SymbolicRule <: AbstractRule end
 
+"""
+    BidirRule <: SymbolicRule
+
+Abstract supertype for rules that may be matched in either direction by an
+e-graph.
+"""
 abstract type BidirRule <: SymbolicRule end
 
 struct RuleRewriteError

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -6,12 +6,10 @@ engine. Rules are callable and return a rewritten value or `nothing`.
 """
 module Rules
 
-using TermInterface
-using AutoHashEquals
-using Metatheory.EMatchCompiler
-using Metatheory.Patterns
-using Metatheory.Patterns: to_expr
-using Metatheory: cleanast, binarize, matcher, instantiate
+import AutoHashEquals: @auto_hash_equals
+import Metatheory.EMatchCompiler: ematcher_yield, ematcher_yield_bidir
+import Metatheory.Patterns: patvars, setdebrujin!
+import Metatheory: instantiate, matcher
 
 const EMPTY_DICT = Base.ImmutableDict{Int,Any}()
 
@@ -21,7 +19,21 @@ const EMPTY_DICT = Base.ImmutableDict{Int,Any}()
 Abstract supertype for all Metatheory rules.
 
 Concrete subtypes must be callable on a term. A rule returns the rewritten term
-when it matches and `nothing` otherwise.
+when it matches and `nothing` otherwise. E-graph saturation additionally
+expects the rule to expose the pattern information required by its matcher.
+
+# Interface contract
+
+Implement `(::MyRule)(term)`, return `nothing` for a non-match, and define
+equality if rules are stored in dictionaries or scheduler state. Subtype
+[`SymbolicRule`](@ref) when the rule has symbolic left and right patterns.
+
+# Example
+
+```julia
+struct IdentityRule <: AbstractRule end
+(::IdentityRule)(term) = term === :x ? :y : nothing
+```
 """
 abstract type AbstractRule end
 # Must override
@@ -31,6 +43,7 @@ Base.:(==)(a::AbstractRule, b::AbstractRule) = false
     SymbolicRule <: AbstractRule
 
 Abstract supertype for rules whose left and right sides are symbolic patterns.
+Subtypes store pattern data and are normally constructed by [`@rule`](@ref).
 """
 abstract type SymbolicRule <: AbstractRule end
 
@@ -38,7 +51,7 @@ abstract type SymbolicRule <: AbstractRule end
     BidirRule <: SymbolicRule
 
 Abstract supertype for rules that may be matched in either direction by an
-e-graph.
+e-graph. Both sides must bind the same variables so either direction is valid.
 """
 abstract type BidirRule <: SymbolicRule end
 
@@ -60,14 +73,20 @@ end
 
 
 """
-Rules defined as `left_hand --> right_hand` are
-called *symbolic rewrite* rules. Application of a *rewrite* Rule
-is a replacement of the `left_hand` pattern with
-the `right_hand` substitution, with the correct instantiation
-of pattern variables. Function call symbols are not treated as pattern
-variables, all other identifiers are treated as pattern variables.
-Literals such as `5, :e, "hello"` are not treated as pattern
-variables.
+    RewriteRule(left, right)
+
+Represent a one-way symbolic substitution rule. Applying the rule replaces the
+matched `left` pattern with `right`, instantiating bound variables. Function
+call symbols and literals are treated as operations/literals; identifiers in
+pattern positions become variables.
+
+# Fields
+
+- `left`, `right`: Pattern trees.
+- `matcher`, `patvars`, `ematcher!`: Compiled matcher state. These fields are
+  implementation details and should not be mutated after construction.
+
+# Example
 
 
 ```julia
@@ -109,9 +128,17 @@ end
 # ============================================================
 
 """
-An `EqualityRule` can is a symbolic substitution rule that 
-can be rewritten bidirectional. Therefore, it should only be used 
-with the EGraphs backend.
+    EqualityRule(left, right)
+
+Represent a bidirectional symbolic equality. It is intended for the EGraphs
+backend, where both orientations are searched; it is not a classical rewriter.
+
+# Fields
+
+- `left`, `right`: Patterns that must bind the same variable names.
+- `patvars`, `ematcher!`: Compiled bidirectional matcher state.
+
+Creating a rule with a variable present on only one side throws an error.
 
 ```julia
 @rule ~a * ~b == ~b * ~a
@@ -149,9 +176,15 @@ end
 # ============================================================
 
 """
-This type of *anti*-rules is used for checking contradictions in the EGraph
-backend. If two terms, corresponding to the left and right hand side of an
-*anti-rule* are found in an [`EGraph`], saturation is halted immediately. 
+    UnequalRule(left, right)
+
+Represent an anti-rule for detecting a contradiction in an EGraph. If both
+patterns are found in one equivalence class, saturation stops immediately.
+
+# Fields
+
+- `left`, `right`: Patterns that must bind the same variable names.
+- `patvars`, `ematcher!`: Compiled matcher state.
 
 ```julia
 !a ≠ a
@@ -183,13 +216,20 @@ Base.show(io::IO, r::UnequalRule) = print(io, :($(r.left) ≠ $(r.right)))
 # DynamicRule
 # ============================================================
 """
-Rules defined as `left_hand => right_hand` are
-called `dynamic` rules. Dynamic rules behave like anonymous functions.
-Instead of a symbolic substitution, the right hand of
-a dynamic `=>` rule is evaluated during rewriting:
-matched values are bound to pattern variables as in a
-regular function call. This allows for dynamic computation
-of right hand sides.
+    DynamicRule(left, rhs_fun[, rhs_code])
+
+Represent a rule whose right-hand side is evaluated for each match. The
+function receives the input term, an analysis context (currently `nothing` for
+classical rewriting), and one positional value per pattern variable.
+
+# Fields
+
+- `left`: Pattern to match.
+- `rhs_fun`: Callable right-hand-side implementation.
+- `rhs_code`, `matcher`, `patvars`, `ematcher!`: Display and compiled matcher
+  state.
+
+Use the [`@rule`](@ref) `=>` form unless constructing a custom rule backend.
 
 Dynamic rule
 ```julia

--- a/src/Rules.jl
+++ b/src/Rules.jl
@@ -28,7 +28,7 @@ Implement `(::MyRule)(term)`, return `nothing` for a non-match, and define
 equality if rules are stored in dictionaries or scheduler state. Subtype
 [`SymbolicRule`](@ref Metatheory.Rules.SymbolicRule) when the rule has symbolic left and right patterns.
 
-# Example
+# Examples
 
 ```julia
 struct IdentityRule <: AbstractRule end
@@ -86,7 +86,7 @@ pattern positions become variables.
 - `matcher`, `patvars`, `ematcher!`: Compiled matcher state. These fields are
   implementation details and should not be mutated after construction.
 
-# Example
+# Examples
 
 
 ```julia

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -5,11 +5,9 @@ Macros for constructing patterns, rewrite rules, and rewrite theories from
 Julia syntax.
 """
 module Syntax
-using Metatheory.Patterns
-using Metatheory.Rules
-using TermInterface
-
-using Metatheory: alwaystrue, cleanast, binarize
+import Metatheory.Patterns: PatSegment, PatTerm, PatVar
+import Metatheory.Rules: DynamicRule, EqualityRule, RewriteRule, SymbolicRule, UnequalRule
+import TermInterface: arguments, exprhead, istree, operation
 
 export @rule
 export @theory
@@ -205,10 +203,10 @@ Creates an `AbstractRule` object. A rule object is callable, and takes an
 expression and rewrites it if it matches the LHS pattern to the RHS pattern,
 returns `nothing` otherwise. The rule language is described below.
 
-LHS can be any possibly nested function call expression where any of the arugments can
+LHS can be any possibly nested function call expression where any of the arguments can
 optionally be a Slot (`~x`) or a Segment (`~x...`) (described below).
 
-SLOTS is an optional list of symbols to be interpeted as slots or segments
+SLOTS is an optional list of symbols to be interpreted as slots or segments
 directly (without using `~`).  To declare slots for several rules at once, see
 the `@slots` macro.
 

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -185,7 +185,7 @@ julia> @slots x y z a b c Chain([
     (@rule +(x...) => sum(x)),
 ])
 ```
-See also: [`@rule`](@ref), [`@capture`](@ref)
+See also: [`@rule`](@ref Metatheory.Syntax.@rule), [`@capture`](@ref Metatheory.Syntax.@capture)
 """
 macro slots(args...)
   length(args) >= 1 || ArgumentError("@slots requires at least one argument")
@@ -328,7 +328,7 @@ Note that this is syntactic sugar and that it is the same as
 
 **Compatibility**:
 Segment variables may still be written as (`~~x`), and slot (`~x`) and segment (`~x...` or `~~x`) syntaxes on the RHS will still substitute the result of the matches.
-See also: [`@capture`](@ref), [`@slots`](@ref)
+See also: [`@capture`](@ref Metatheory.Syntax.@capture), [`@slots`](@ref Metatheory.Syntax.@slots)
 """
 macro rule(args...)
   length(args) >= 1 || ArgumentError("@rule requires at least one argument")
@@ -421,7 +421,7 @@ julia> if @capture ex (~x)^(~x)
        end;
 x = a
 ```
-See also: [`@rule`](@ref)
+See also: [`@rule`](@ref Metatheory.Syntax.@rule)
 """
 macro capture(args...)
   length(args) >= 2 || ArgumentError("@capture requires at least two arguments")

--- a/src/Syntax.jl
+++ b/src/Syntax.jl
@@ -1,3 +1,9 @@
+"""
+    Syntax
+
+Macros for constructing patterns, rewrite rules, and rewrite theories from
+Julia syntax.
+"""
 module Syntax
 using Metatheory.Patterns
 using Metatheory.Rules

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,13 +1,9 @@
 ## Docstring Templates
 
-import DocStringExtensions: @template, DOCSTRING, IMPORTS, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
+import DocStringExtensions: @template, DOCSTRING, IMPORTS, TYPEDEF, TYPEDFIELDS
 
 @template (FUNCTIONS, METHODS, MACROS) = """
                                          $(DOCSTRING)
-
-                                         ---
-                                         # Signatures
-                                         $(TYPEDSIGNATURES)
                                          """
 
 @template (TYPES) = """

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,6 +1,6 @@
 ## Docstring Templates
 
-import DocStringExtensions: @template, DOCSTRING, IMPORTS, METHODLIST, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
+import DocStringExtensions: @template, DOCSTRING, IMPORTS, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 
 @template (FUNCTIONS, METHODS, MACROS) = """
                                          $(DOCSTRING)
@@ -8,9 +8,6 @@ import DocStringExtensions: @template, DOCSTRING, IMPORTS, METHODLIST, TYPEDEF, 
                                          ---
                                          # Signatures
                                          $(TYPEDSIGNATURES)
-                                         ---
-                                         ## Methods
-                                         $(METHODLIST)
                                          """
 
 @template (TYPES) = """

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,6 +1,6 @@
 ## Docstring Templates
 
-using DocStringExtensions
+import DocStringExtensions: @template, DOCSTRING, IMPORTS, METHODLIST, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 
 @template (FUNCTIONS, METHODS, MACROS) = """
                                          $(DOCSTRING)

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,9 +1,15 @@
 ## Docstring Templates
 
-import DocStringExtensions: @template, DOCSTRING, IMPORTS, TYPEDEF, TYPEDFIELDS
+import DocStringExtensions: @template, DOCSTRING, IMPORTS, METHODLIST, TYPEDEF, TYPEDFIELDS, TYPEDSIGNATURES
 
 @template (FUNCTIONS, METHODS, MACROS) = """
                                          $(DOCSTRING)
+                                         ---
+                                         # Signatures
+                                         $(TYPEDSIGNATURES)
+                                         ---
+                                         ## Methods
+                                         $(METHODLIST)
                                          """
 
 @template (TYPES) = """

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -4,7 +4,7 @@
 Internal compiler support for turning patterns into e-graph matchers.
 
 The exported matcher constructors are developer-facing APIs used by custom
-rule backends; ordinary users should construct rules with [`@rule`](@ref).
+rule backends; ordinary users should construct rules with [`@rule`](@ref Metatheory.Syntax.@rule).
 """
 module EMatchCompiler
 
@@ -167,7 +167,7 @@ Compile both directions of a bidirectional pattern match.
 
 # Arguments
 
-- `left`, `right`: Left and right patterns of a [`BidirRule`](@ref).
+- `left`, `right`: Left and right patterns of a [`BidirRule`](@ref Metatheory.Rules.BidirRule).
 - `npvars::Int`: Number of pattern variables.
 
 The returned callable accepts `(egraph, rule_index, eclass_id)`, appends

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -1,3 +1,11 @@
+"""
+    EMatchCompiler
+
+Internal compiler support for turning patterns into e-graph matchers.
+
+The exported matcher constructors are developer-facing APIs used by custom
+rule backends; ordinary users should construct rules with [`@rule`](@ref).
+"""
 module EMatchCompiler
 
 using TermInterface
@@ -152,6 +160,19 @@ end
 
 ematcher_yield(p, npvars) = ematcher_yield(p, npvars, 1)
 
+"""
+    ematcher_yield_bidir(left, right, npvars)
+
+Compile both directions of a bidirectional pattern match.
+
+# Arguments
+
+- `left`, `right`: Left and right patterns of a [`BidirRule`](@ref).
+- `npvars::Int`: Number of pattern variables.
+
+The returned callable accepts `(egraph, rule_index, eclass_id)`, appends
+matches to the e-graph buffer, and returns the number of matches.
+"""
 function ematcher_yield_bidir(l, r, npvars::Int)
   eml, emr = ematcher_yield(l, npvars, 1), ematcher_yield(r, npvars, -1)
   function ematcher_yield_bidir(g, rule_idx, id)::Int

--- a/src/ematch_compiler.jl
+++ b/src/ematch_compiler.jl
@@ -8,9 +8,9 @@ rule backends; ordinary users should construct rules with [`@rule`](@ref).
 """
 module EMatchCompiler
 
-using TermInterface
-using ..Patterns
-using Metatheory: islist, car, cdr, assoc, drop_n, lookup_pat, LL, maybelock!
+import TermInterface: arguments, arity, exprhead, istree, operation, symtype
+import ..Patterns: PatTerm, PatVar, isground
+import Metatheory: assoc, car, cdr, drop_n, islist, LL, lookup_pat, maybelock!
 
 function ematcher(p::Any)
   function literal_ematcher(next, g, data, bindings)
@@ -72,8 +72,8 @@ function ematcher(p::PatVar)
   end
 end
 
-Base.@pure @inline checkop(x::Union{Function,DataType}, op) = isequal(x, op) || isequal(nameof(x), op)
-Base.@pure @inline checkop(x, op) = isequal(x, op)
+@inline checkop(x::Union{Function,DataType}, op) = isequal(x, op) || isequal(nameof(x), op)
+@inline checkop(x, op) = isequal(x, op)
 
 function canbind(p::PatTerm)
   eh = exprhead(p)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,6 +148,16 @@ function merge_repeats(merge, xs)
 end
 
 # Take a struct definition and make it be able to match in `@rule`
+"""
+    @matchable struct_definition
+
+Declare a struct and add the TermInterface methods required for pattern
+matching.
+
+The generated `operation` is the struct type and the generated `arguments` are
+its fields in declaration order. The input must be a plain Julia `struct`
+expression.
+"""
 macro matchable(expr)
   @assert expr.head == :struct
   name = expr.args[2]
@@ -174,6 +184,12 @@ using TimerOutputs
 
 const being_timed = Ref{Bool}(false)
 
+"""
+    @timer name expr
+
+Evaluate `expr` and record its time under `name` when Metatheory timing is
+enabled.
+"""
 macro timer(name, expr)
   :(
     if being_timed[]
@@ -184,6 +200,11 @@ macro timer(name, expr)
   )
 end
 
+"""
+    @iftimer expr
+
+Evaluate `expr` while preserving Metatheory's timing instrumentation setting.
+"""
 macro iftimer(expr)
   esc(expr)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -180,7 +180,7 @@ macro matchable(expr)
 end
 
 
-using TimerOutputs
+import TimerOutputs: @timeit, print_timer, reset_timer!
 
 const being_timed = Ref{Bool}(false)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -180,7 +180,7 @@ macro matchable(expr)
 end
 
 
-import TimerOutputs: @timeit, print_timer, reset_timer!
+import TimerOutputs: print_timer, reset_timer!, timeit
 
 const being_timed = Ref{Bool}(false)
 
@@ -193,7 +193,7 @@ enabled.
 macro timer(name, expr)
   :(
     if being_timed[]
-      @timeit $(esc(name)) $(esc(expr))
+      timeit(() -> $(esc(expr)), $(esc(name)))
     else
       $(esc(expr))
     end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Metatheory = "e9d8d322-4543-424a-9be4-0cc815abe26c"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+JET = "0.9, 0.10, 0.11, 0.12"
+SciMLTesting = "2.4"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,9 @@
+using JET
+using Metatheory
+using SciMLTesting
+
+run_qa(
+  Metatheory;
+  aqua_kwargs = (; piracies = (; treat_as_own = (Expr,))),
+  reexports_allow = (:EClassId, :arity, :merge!),
+)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,10 @@ function run_core_tests()
     @test Metatheory.EGraphs.Schedulers.inform!(scheduler, rule, 0)
     Metatheory.EGraphs.Schedulers.setiter!(scheduler, 3)
     @test scheduler.iteration == 3
+
+    leaf_rewriter = Metatheory.Rewriters.IfElse(x -> x isa Expr, _ -> :leaf, Metatheory.Rewriters.Empty())
+    @test Metatheory.Rewriters.Prewalk(leaf_rewriter; threaded = true, thread_cutoff = 0)(:(f(x))) === :leaf
+    @test Metatheory.Rewriters.Postwalk(leaf_rewriter; threaded = true, thread_cutoff = 0)(:(f(x))) === :leaf
   end
 
   function test(file::String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,44 @@ using Test
 
 doctest(Metatheory)
 
+struct ContractGoal <: Metatheory.EGraphs.SaturationGoal end
+Metatheory.EGraphs.reached(::Metatheory.EGraphs.EGraph, ::ContractGoal) = true
+struct ContractRule <: Metatheory.Rules.AbstractRule end
+
+mutable struct ContractScheduler <: Metatheory.EGraphs.Schedulers.AbstractScheduler
+  iteration::Int
+end
+
+ContractScheduler(
+    ::Metatheory.EGraphs.EGraph,
+    ::Vector{<:Metatheory.Rules.AbstractRule},
+) = ContractScheduler(0)
+Metatheory.EGraphs.Schedulers.cansaturate(::ContractScheduler) = false
+Metatheory.EGraphs.Schedulers.cansearch(::ContractScheduler, ::Metatheory.Rules.AbstractRule) = true
+Metatheory.EGraphs.Schedulers.inform!(::ContractScheduler, ::Metatheory.Rules.AbstractRule, ::Int) = true
+Metatheory.EGraphs.Schedulers.setiter!(scheduler::ContractScheduler, iteration) =
+  scheduler.iteration = iteration
+
+@testset "Generic interface contracts" begin
+  g = Metatheory.EGraphs.EGraph(1)
+  goal = ContractGoal()
+  @test Metatheory.EGraphs.reached(g, goal)
+
+  params = Metatheory.EGraphs.SaturationParams(
+    goal=goal, scheduler=ContractScheduler, timeout=2, timer=false)
+  report = Metatheory.EGraphs.saturate!(
+    g, Metatheory.Rules.AbstractRule[], params)
+  @test report.reason === :goalreached
+  @test report.iterations == 1
+
+  scheduler = ContractScheduler(0)
+  rule = ContractRule()
+  @test Metatheory.EGraphs.Schedulers.cansearch(scheduler, rule)
+  @test Metatheory.EGraphs.Schedulers.inform!(scheduler, rule, 0)
+  Metatheory.EGraphs.Schedulers.setiter!(scheduler, 3)
+  @test scheduler.iteration == 3
+end
+
 function test(file::String)
   @info file
   @eval @time @safetestset $file begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using SafeTestsets
 using Documenter
 using Metatheory
+using SciMLTesting
 using Test
-
-doctest(Metatheory)
 
 struct ContractGoal <: Metatheory.EGraphs.SaturationGoal end
 Metatheory.EGraphs.reached(::Metatheory.EGraphs.EGraph, ::ContractGoal) = true
@@ -13,57 +12,57 @@ mutable struct ContractScheduler <: Metatheory.EGraphs.Schedulers.AbstractSchedu
   iteration::Int
 end
 
-ContractScheduler(
-    ::Metatheory.EGraphs.EGraph,
-    ::Vector{<:Metatheory.Rules.AbstractRule},
-) = ContractScheduler(0)
+ContractScheduler(::Metatheory.EGraphs.EGraph, ::Vector{<:Metatheory.Rules.AbstractRule}) = ContractScheduler(0)
 Metatheory.EGraphs.Schedulers.cansaturate(::ContractScheduler) = false
 Metatheory.EGraphs.Schedulers.cansearch(::ContractScheduler, ::Metatheory.Rules.AbstractRule) = true
 Metatheory.EGraphs.Schedulers.inform!(::ContractScheduler, ::Metatheory.Rules.AbstractRule, ::Int) = true
-Metatheory.EGraphs.Schedulers.setiter!(scheduler::ContractScheduler, iteration) =
-  scheduler.iteration = iteration
+Metatheory.EGraphs.Schedulers.setiter!(scheduler::ContractScheduler, iteration) = scheduler.iteration = iteration
 
-@testset "Generic interface contracts" begin
-  g = Metatheory.EGraphs.EGraph(1)
-  goal = ContractGoal()
-  @test Metatheory.EGraphs.reached(g, goal)
+function run_core_tests()
+  doctest(Metatheory)
 
-  params = Metatheory.EGraphs.SaturationParams(
-    goal=goal, scheduler=ContractScheduler, timeout=2, timer=false)
-  report = Metatheory.EGraphs.saturate!(
-    g, Metatheory.Rules.AbstractRule[], params)
-  @test report.reason === :goalreached
-  @test report.iterations == 1
+  @testset "Generic interface contracts" begin
+    g = Metatheory.EGraphs.EGraph(1)
+    goal = ContractGoal()
+    @test Metatheory.EGraphs.reached(g, goal)
 
-  scheduler = ContractScheduler(0)
-  rule = ContractRule()
-  @test Metatheory.EGraphs.Schedulers.cansearch(scheduler, rule)
-  @test Metatheory.EGraphs.Schedulers.inform!(scheduler, rule, 0)
-  Metatheory.EGraphs.Schedulers.setiter!(scheduler, 3)
-  @test scheduler.iteration == 3
-end
+    params = Metatheory.EGraphs.SaturationParams(goal = goal, scheduler = ContractScheduler, timeout = 2, timer = false)
+    report = Metatheory.EGraphs.saturate!(g, Metatheory.Rules.AbstractRule[], params)
+    @test report.reason === :goalreached
+    @test report.iterations == 1
 
-function test(file::String)
-  @info file
-  @eval @time @safetestset $file begin
-    include(joinpath(@__DIR__, $file))
+    scheduler = ContractScheduler(0)
+    rule = ContractRule()
+    @test Metatheory.EGraphs.Schedulers.cansearch(scheduler, rule)
+    @test Metatheory.EGraphs.Schedulers.inform!(scheduler, rule, 0)
+    Metatheory.EGraphs.Schedulers.setiter!(scheduler, 3)
+    @test scheduler.iteration == 3
+  end
+
+  function test(file::String)
+    @info file
+    @eval @time @safetestset $file begin
+      include(joinpath(@__DIR__, $file))
+    end
+  end
+
+  allscripts(dir) = [joinpath(@__DIR__, dir, x) for x in readdir(dir) if endswith(x, ".jl")]
+
+  test_files = [
+    allscripts("classic")
+    allscripts("egraphs")
+    allscripts("integration")
+    allscripts("tutorials")
+  ]
+
+  @timev map(test, test_files)
+
+  # exported consistency test
+  for m in [Metatheory, Metatheory.EGraphs, Metatheory.EGraphs.Schedulers]
+    for i in propertynames(m)
+      !hasproperty(m, i) && error("Module $m exports undefined symbol $i")
+    end
   end
 end
 
-allscripts(dir) = [joinpath(@__DIR__, dir, x) for x in readdir(dir) if endswith(x, ".jl")]
-
-const TEST_FILES = [
-  allscripts("classic")
-  allscripts("egraphs")
-  allscripts("integration")
-  allscripts("tutorials")
-]
-
-@timev map(test, TEST_FILES)
-
-# exported consistency test
-for m in [Metatheory, Metatheory.EGraphs, Metatheory.EGraphs.Schedulers]
-  for i in propertynames(m)
-    !hasproperty(m, i) && error("Module $m exports undefined symbol $i")
-  end
-end
+run_tests(core = run_core_tests, qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")))

--- a/test/tutorials/calculational_logic.jl
+++ b/test/tutorials/calculational_logic.jl
@@ -1,5 +1,6 @@
 # # Rewriting Calculational Logic
 using Metatheory
+using Test
 
 include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_theory.jl"))
 
@@ -13,16 +14,16 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/calculational_logic_t
   @test @areequal calculational_logic_theory true ((!p == !p) == true)
   @test @areequal calculational_logic_theory true ((!p || !p) == !p) (!p || p) !(!p && p)
   @test @areequal calculational_logic_theory true ((p ⟹ (p || p)) == true)
-  params = SaturationParams(timeout = 12, eclasslimit = 10000, schedulerparams = (1000, 5))
+  params = SaturationParams(timeout = 120, eclasslimit = 10000, schedulerparams = (1000, 5))
 
   @test areequal(calculational_logic_theory, true, :(((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)) == true); params = params)
 
-  # Frege's theorem
+  #= Frege's theorem =#
   @test areequal(calculational_logic_theory, true, :((p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))); params = params)
 
-  # Demorgan's
+  #= Demorgan's =#
   @test @areequal calculational_logic_theory true (!(p || q) == (!p && !q))
 
-  # Consensus theorem
+  #= Consensus theorem =#
   areequal(calculational_logic_theory, :((x && y) || (!x && z) || (y && z)), :((x && y) || (!x && z)); params = params)
 end

--- a/test/tutorials/propositional_logic.jl
+++ b/test/tutorials/propositional_logic.jl
@@ -18,8 +18,10 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_t
   @test @areequal propositional_logic_theory true ((p ⟹ (p || p)))
   @test @areequal propositional_logic_theory true ((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)) == true
 
+  #= Frege's theorem =#
   @test @areequal propositional_logic_theory true (p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))
 
+  #= Demorgan's =#
   @test @areequal propositional_logic_theory true (!(p || q) == (!p && !q))
 
   @test areequal(

--- a/test/tutorials/propositional_logic.jl
+++ b/test/tutorials/propositional_logic.jl
@@ -8,7 +8,7 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_t
 
 @testset "Prop logic" begin
   ex = rewrite(:(((p ⟹ q) && (r ⟹ s) && (p || r)) ⟹ (q || s)), impl)
-  @test prove(propositional_logic_theory, ex, 5, 10, 5000)
+  @test prove(propositional_logic_theory, ex, 5, 10)
 
 
   @test @areequal propositional_logic_theory true ((!p == p) == false)
@@ -18,12 +18,14 @@ include(joinpath(dirname(pathof(Metatheory)), "../examples/propositional_logic_t
   @test @areequal propositional_logic_theory true ((p ⟹ (p || p)))
   @test @areequal propositional_logic_theory true ((p ⟹ (p || p)) == ((!(p) && q) ⟹ q)) == true
 
-  # Frege's theorem
   @test @areequal propositional_logic_theory true (p ⟹ (q ⟹ r)) ⟹ ((p ⟹ q) ⟹ (p ⟹ r))
 
-  # Demorgan's
   @test @areequal propositional_logic_theory true (!(p || q) == (!p && !q))
 
-  # Consensus theorem
-  # @test_broken @areequal propositional_logic_theory true ((x && y) || (!x && z) || (y && z)) ((x && y) || (!x && z))
+  @test areequal(
+    propositional_logic_theory,
+    :((x && y) || (!x && z) || (y && z)),
+    :((x && y) || (!x && z));
+    params = SaturationParams(timeout = 120),
+  )
 end

--- a/test/tutorials/while_interpreter.jl
+++ b/test/tutorials/while_interpreter.jl
@@ -24,7 +24,7 @@ WHILE is implemented in around 55 readable lines of code, and reaches around 80 
 
 The goal of this tutorial is to show an implementation of a programming language interpreter that is very, very very close to the
 simple theory used to describe it in a textbook. Each denotational semantics rule in the course notes is a Metatheory.jl rewrite rule, with a few extras and minor naming changes. 
-The idea, is that Julia is a really valid didactical programming language! 
+The idea, is that Julia is a really valid didactic programming language!
 
 =#
 
@@ -99,23 +99,23 @@ end
 
 # ## Evaluation strategy
 # We now have some nice denotational semantic rules for arithmetics, but in what order should we apply them?
-# Metatheory.jl provides a flexible rewriter combinator library. You can read more in the [Rewriters](@ref) module docs. 
+# Metatheory.jl provides a flexible rewriter combinator library. You can read more in the [Rewriters](@ref Metatheory.Rewriters) module docs.
 #
 # Given a set of rules, we can define  a rewriter strategy by functionally composing rewriters.
 # First, we want to use `Chain` to combine together the many rules in the theory, and to try to apply them one-by-one on our expressions.
 #
 # But should we first evaluate the outermost operations in the expression, or the innermost?
 # Intuitively, if we have the program `(1 + 2) - 3`, it can hint us that we do want to first evaluate the innermost expressions.
-# To do so, we then pass the result to the [Postwalk](@ref) rewriter, which recursively walks the input expression tree, and applies the rewriter first on 
-# the inner expressions, and then, on the outer, rewritten expression. (Hence the name `Post`-walk. Can you guess what [Prewalk](@ref) does?).
+# To do so, we then pass the result to the [Postwalk](@ref Metatheory.Rewriters.Postwalk) rewriter, which recursively walks the input expression tree, and applies the rewriter first on
+# the inner expressions, and then, on the outer, rewritten expression. (Hence the name `Post`-walk. Can you guess what [Prewalk](@ref Metatheory.Rewriters.Prewalk) does?).
 #
-# The last component of our strategy is the [Fixpoint](@ref) combinator. This combinator repeatedly applies the rewriter on the input expression,
+# The last component of our strategy is the [Fixpoint](@ref Metatheory.Rewriters.Fixpoint) combinator. This combinator repeatedly applies the rewriter on the input expression,
 # and it does stop looping only when the output expression is the unchanged input expression.
 
 using Metatheory.Rewriters
 strategy = (Fixpoint ∘ Postwalk ∘ Chain)
 
-# In Metatheory.jl, rewrite theories are just vectors of [Rules](@ref). It means we can compose them by concatenating the vectors, or elegantly using the 
+# In Metatheory.jl, rewrite theories are just vectors of [Rules](@ref Metatheory.Rules). It means we can compose them by concatenating the vectors, or elegantly using the
 # built-in set operations provided by the Julia language.
 arithm_lang = read_mem ∪ arithm_rules
 


### PR DESCRIPTION
## Scope

Fixed the `Metatheory_vs_egg` workflow artifact handoff while keeping the package change limited to the public API documentation and strict QA work already in this draft PR. The egg and Metatheory benchmark commands now capture the logs at the root-relative paths consumed by `egg-benchmark/scripts/load_results.jl`; no package code, benchmark logic, or test assertions were changed.

## Reproduction

The failing loader was reproduced before the fix on both revisions:

- PR head `27173b561852ff2f13a1682db13b55f7f0720ebd`: `load_results.jl` exited `1` with `SystemError: opening file "./target/mt_results/mt-log.txt": No such file or directory` at `load_size_results!` line 93.
- Base `4fb45dfc2caa80c03e8d4252eac69ec277426f65`: the same command exited `1` with the same missing-file error at the same line.

The benchmark JSON results existed in both cases; the workflow had run `cargo bench` and `benchpkg` without saving `target/egg-log.txt` or `target/mt_results/mt-log.txt`.

## Fix Evidence

After the workflow change, the equivalent local sequence completed with `cargo_and_loader_exit=0`. The loader produced both the benchmark comparison table and size table, with `target/egg-log.txt` (`228914` bytes), `target/mt_results/mt-log.txt` (`10468` bytes), and `fixed-table.md` (`4645` bytes).

## Verification

- `GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'`: `QA | 21 passed, 21 total`; `Testing Metatheory tests passed`.
- `julia --project=. -e 'using Pkg; Pkg.test()'`: all package tests passed; doctests `1/1`, full test run ended with `Testing Metatheory tests passed`.
- `/home/crackauc/.julia/juliaup/julia-1.11.9+0.x64.linux.gnu/bin/julia --project=docs docs/make.jl`: passed doctests, cross-references, document checks, and HTML rendering.
- `typos --file-list - --format brief` over `git diff --name-only origin/master`: passed.
- `git diff --check`: passed.
- JuliaFormatter check mode: all changed Julia files passed except the existing literate `test/tutorials/while_interpreter.jl` formatting exception around an executable `@theory` block; write-mode formatting would rewrite that example.
- `actionlint .github/workflows/benchmark_pr.yml`: YAML parsed, with only the existing SC2086/SC2129 shellcheck findings on unchanged workflow lines.

The benchmark job itself is pending on the pushed commit. GPU, downstream, and credential-dependent checks were not run locally.

Please ignore this draft PR until reviewed by @ChrisRackauckas.

## Links

- Commit: https://github.com/JuliaSymbolics/Metatheory.jl/commit/cca0db99806c7376bd12e8839999b2189b56d223
- Pull request: https://github.com/JuliaSymbolics/Metatheory.jl/pull/289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://github.com/JuliaSymbolics/Metatheory.jl/pull/289
